### PR TITLE
this fixes malformed sql for getIndexInfo

### DIFF
--- a/src/main/java/org/sqlite/util/StringUtils.java
+++ b/src/main/java/org/sqlite/util/StringUtils.java
@@ -1,0 +1,19 @@
+package org.sqlite.util;
+
+import java.util.List;
+
+public class StringUtils {
+    public static String join(List<String> list, String separator) {
+        StringBuilder sb = new StringBuilder();
+        boolean first = true;
+        for(String item : list) {
+            if (first)
+                first = false;
+            else
+                sb.append(separator);
+
+            sb.append(item);
+        }
+        return sb.toString();
+    }
+}

--- a/src/test/java/org/sqlite/DBMetaDataTest.java
+++ b/src/test/java/org/sqlite/DBMetaDataTest.java
@@ -646,6 +646,40 @@ public class DBMetaDataTest
     }
 
     @Test
+    public void getIndexInfoOnTest() throws SQLException {
+        ResultSet rs = meta.getIndexInfo(null,null,"test",false,false);
+
+        assertNotNull(rs);
+    }
+
+    @Test
+    public void getIndexInfoIndexedSingle() throws SQLException {
+        stat.executeUpdate("create table testindex (id integer primary key, fn float default 0.0, sn not null);");
+        stat.executeUpdate("create index testindex_idx on testindex (sn);");
+
+        ResultSet rs = meta.getIndexInfo(null,null,"testindex",false,false);
+        ResultSetMetaData rsmd = rs.getMetaData();
+
+        assertNotNull(rs);
+        assertNotNull(rsmd);
+    }
+
+
+    @Test
+    public void getIndexInfoIndexedMulti() throws SQLException {
+        stat.executeUpdate("create table testindex (id integer primary key, fn float default 0.0, sn not null);");
+        stat.executeUpdate("create index testindex_idx on testindex (sn);");
+        stat.executeUpdate("create index testindex_pk_idx on testindex (id);");
+
+        ResultSet rs = meta.getIndexInfo(null,null,"testindex",false,false);
+        ResultSetMetaData rsmd = rs.getMetaData();
+
+        assertNotNull(rs);
+        assertNotNull(rsmd);
+    }
+
+
+    @Test
     public void version() throws SQLException {
         assertNotNull(meta.getDatabaseProductVersion());
     }


### PR DESCRIPTION
sqlite stopped throwing an exception on

```
pragma index_list("table");
```

Which was causing the sql generated by the getIndexInfo method
to be corrupt.

java.sql.SQLException: [SQLITE_ERROR] SQL error or missing database (near
"1": syntax error)

This patch fixes this issue

https://bitbucket.org/xerial/sqlite-jdbc/issue/134/metadatagetindexinfo-throws-exception
