### PR TITLE
return null if unhandled url protocol

### DIFF
--- a/src/main/java/org/sqlite/JDBC.java
+++ b/src/main/java/org/sqlite/JDBC.java
@@ -108,7 +108,7 @@ public class JDBC implements Driver
      */
     public static Connection createConnection(String url, Properties prop) throws SQLException {
         if (!isValidURL(url))
-            throw new SQLException("invalid database address: " + url);
+            return null;
 
         url = url.trim();
         return new SQLiteConnection(url, extractAddress(url), prop);

--- a/src/test/java/org/sqlite/JDBCTest.java
+++ b/src/test/java/org/sqlite/JDBCTest.java
@@ -14,6 +14,7 @@ import java.sql.DriverManager;
 import java.sql.Statement;
 import java.util.Properties;
 
+import junit.framework.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -49,6 +50,11 @@ public class JDBCTest
     public void majorVersion() throws Exception {
         int major = DriverManager.getDriver("jdbc:sqlite:").getMajorVersion();
         int minor = DriverManager.getDriver("jdbc:sqlite:").getMinorVersion();
+    }
+
+    @Test
+    public void shouldReturnNullIfProtocolUnhandled() throws Exception {
+        Assert.assertNull(JDBC.createConnection("jdbc:anotherpopulardatabaseprotocol:", null));
     }
 
 }


### PR DESCRIPTION
I don't think any additional checks are required, because the underlying methods will try to establish connection and throw a `SQLException` if it fails, and that is in accordance with the spec.