### PR TITLE
Fix case-mangling of URL parameters

### DIFF
--- a/src/main/java/org/sqlite/core/CoreConnection.java
+++ b/src/main/java/org/sqlite/core/CoreConnection.java
@@ -115,8 +115,8 @@ public abstract class CoreConnection {
     			continue;
     		}
 
-    		String [] kvp = parameter.toLowerCase().split("=");
-    		String key = kvp[0].trim();
+    		String [] kvp = parameter.split("=");
+    		String key = kvp[0].trim().toLowerCase();
     		if (pragmaSet.contains(key)) {
     			if (kvp.length == 1) {
     				throw new SQLException(String.format("Please specify a value for PRAGMA %s in URL %s", key, url));


### PR DESCRIPTION
One convenient use of the URL parameters is to specify the date format.  Unfortunately the URL parameter value was aggressively lower-cased which breaks many supplied date formats.  Now you can properly specify a case-sensitive date format.