### PR TITLE
Use Apache Commons FastDateFormat instead of SimpleDateFormat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ src/main/resources/org/ibex/nestedvm/*.o
 .idea
 *.iml
 atlassian-ide-plugin.xml
+.classpath
+.project

--- a/src/main/java/org/sqlite/core/CoreConnection.java
+++ b/src/main/java/org/sqlite/core/CoreConnection.java
@@ -10,13 +10,13 @@ import java.net.URL;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.TreeSet;
+
+import org.sqlite.date.FastDateFormat;
 
 import org.sqlite.SQLiteConfig;
 import org.sqlite.SQLiteConfig.DateClass;
@@ -56,7 +56,8 @@ public abstract class CoreConnection {
     public final DateClass dateClass;
     public final DatePrecision datePrecision; //Calendar.SECOND or Calendar.MILLISECOND
     public final long dateMultiplier;
-    public final DateFormat dateFormat;
+    public final FastDateFormat dateFormat;
+    public final String dateStringFormat;
 
     protected CoreConnection(String url, String fileName, Properties prop) throws SQLException
     {
@@ -66,7 +67,8 @@ public abstract class CoreConnection {
         SQLiteConfig config = new SQLiteConfig(prop);
         this.dateClass = config.dateClass;
         this.dateMultiplier = config.dateMultiplier;
-        this.dateFormat = new SimpleDateFormat(config.dateStringFormat);
+        this.dateFormat = FastDateFormat.getInstance(config.dateStringFormat);
+        this.dateStringFormat = config.dateStringFormat;
         this.datePrecision = config.datePrecision;
         this.transactionMode = config.getTransactionMode();
         this.openModeFlags = config.getOpenModeFlags();

--- a/src/main/java/org/sqlite/date/DateFormatUtils.java
+++ b/src/main/java/org/sqlite/date/DateFormatUtils.java
@@ -1,0 +1,323 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sqlite.date;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
+
+/**
+ * <p>Date and time formatting utilities and constants.</p>
+ *
+ * <p>Formatting is performed using the thread-safe
+ * {@link org.apache.commons.lang3.time.FastDateFormat} class.</p>
+ *
+ * <p>Note that the JDK has a bug wherein calling Calendar.get(int) will 
+ * override any previously called Calendar.clear() calls. See LANG-755.</p>
+ *
+ * @since 2.0
+ * @version $Id$
+ */
+public class DateFormatUtils {
+
+    /**
+     * The UTC time zone (often referred to as GMT).
+     * This is private as it is mutable.
+     */
+    private static final TimeZone UTC_TIME_ZONE = TimeZone.getTimeZone("GMT");
+    /**
+     * ISO 8601 formatter for date-time without time zone.
+     * The format used is {@code yyyy-MM-dd'T'HH:mm:ss}.
+     */
+    public static final FastDateFormat ISO_DATETIME_FORMAT
+            = FastDateFormat.getInstance("yyyy-MM-dd'T'HH:mm:ss");
+
+    /**
+     * ISO 8601 formatter for date-time with time zone.
+     * The format used is {@code yyyy-MM-dd'T'HH:mm:ssZZ}.
+     */
+    public static final FastDateFormat ISO_DATETIME_TIME_ZONE_FORMAT
+            = FastDateFormat.getInstance("yyyy-MM-dd'T'HH:mm:ssZZ");
+
+    /**
+     * ISO 8601 formatter for date without time zone.
+     * The format used is {@code yyyy-MM-dd}.
+     */
+    public static final FastDateFormat ISO_DATE_FORMAT
+            = FastDateFormat.getInstance("yyyy-MM-dd");
+
+    /**
+     * ISO 8601-like formatter for date with time zone.
+     * The format used is {@code yyyy-MM-ddZZ}.
+     * This pattern does not comply with the formal ISO 8601 specification
+     * as the standard does not allow a time zone  without a time.
+     */
+    public static final FastDateFormat ISO_DATE_TIME_ZONE_FORMAT
+            = FastDateFormat.getInstance("yyyy-MM-ddZZ");
+
+    /**
+     * ISO 8601 formatter for time without time zone.
+     * The format used is {@code 'T'HH:mm:ss}.
+     */
+    public static final FastDateFormat ISO_TIME_FORMAT
+            = FastDateFormat.getInstance("'T'HH:mm:ss");
+
+    /**
+     * ISO 8601 formatter for time with time zone.
+     * The format used is {@code 'T'HH:mm:ssZZ}.
+     */
+    public static final FastDateFormat ISO_TIME_TIME_ZONE_FORMAT
+            = FastDateFormat.getInstance("'T'HH:mm:ssZZ");
+
+    /**
+     * ISO 8601-like formatter for time without time zone.
+     * The format used is {@code HH:mm:ss}.
+     * This pattern does not comply with the formal ISO 8601 specification
+     * as the standard requires the 'T' prefix for times.
+     */
+    public static final FastDateFormat ISO_TIME_NO_T_FORMAT
+            = FastDateFormat.getInstance("HH:mm:ss");
+
+    /**
+     * ISO 8601-like formatter for time with time zone.
+     * The format used is {@code HH:mm:ssZZ}.
+     * This pattern does not comply with the formal ISO 8601 specification
+     * as the standard requires the 'T' prefix for times.
+     */
+    public static final FastDateFormat ISO_TIME_NO_T_TIME_ZONE_FORMAT
+            = FastDateFormat.getInstance("HH:mm:ssZZ");
+
+    /**
+     * SMTP (and probably other) date headers.
+     * The format used is {@code EEE, dd MMM yyyy HH:mm:ss Z} in US locale.
+     */
+    public static final FastDateFormat SMTP_DATETIME_FORMAT
+            = FastDateFormat.getInstance("EEE, dd MMM yyyy HH:mm:ss Z", Locale.US);
+
+    //-----------------------------------------------------------------------
+    /**
+     * <p>DateFormatUtils instances should NOT be constructed in standard programming.</p>
+     *
+     * <p>This constructor is public to permit tools that require a JavaBean instance
+     * to operate.</p>
+     */
+    public DateFormatUtils() {
+        super();
+    }
+
+    /**
+     * <p>Formats a date/time into a specific pattern using the UTC time zone.</p>
+     * 
+     * @param millis  the date to format expressed in milliseconds
+     * @param pattern  the pattern to use to format the date, not null
+     * @return the formatted date
+     */
+    public static String formatUTC(final long millis, final String pattern) {
+        return format(new Date(millis), pattern, UTC_TIME_ZONE, null);
+    }
+
+    /**
+     * <p>Formats a date/time into a specific pattern using the UTC time zone.</p>
+     * 
+     * @param date  the date to format, not null
+     * @param pattern  the pattern to use to format the date, not null
+     * @return the formatted date
+     */
+    public static String formatUTC(final Date date, final String pattern) {
+        return format(date, pattern, UTC_TIME_ZONE, null);
+    }
+    
+    /**
+     * <p>Formats a date/time into a specific pattern using the UTC time zone.</p>
+     * 
+     * @param millis  the date to format expressed in milliseconds
+     * @param pattern  the pattern to use to format the date, not null
+     * @param locale  the locale to use, may be <code>null</code>
+     * @return the formatted date
+     */
+    public static String formatUTC(final long millis, final String pattern, final Locale locale) {
+        return format(new Date(millis), pattern, UTC_TIME_ZONE, locale);
+    }
+
+    /**
+     * <p>Formats a date/time into a specific pattern using the UTC time zone.</p>
+     * 
+     * @param date  the date to format, not null
+     * @param pattern  the pattern to use to format the date, not null
+     * @param locale  the locale to use, may be <code>null</code>
+     * @return the formatted date
+     */
+    public static String formatUTC(final Date date, final String pattern, final Locale locale) {
+        return format(date, pattern, UTC_TIME_ZONE, locale);
+    }
+    
+    /**
+     * <p>Formats a date/time into a specific pattern.</p>
+     * 
+     * @param millis  the date to format expressed in milliseconds
+     * @param pattern  the pattern to use to format the date, not null
+     * @return the formatted date
+     */
+    public static String format(final long millis, final String pattern) {
+        return format(new Date(millis), pattern, null, null);
+    }
+
+    /**
+     * <p>Formats a date/time into a specific pattern.</p>
+     * 
+     * @param date  the date to format, not null
+     * @param pattern  the pattern to use to format the date, not null
+     * @return the formatted date
+     */
+    public static String format(final Date date, final String pattern) {
+        return format(date, pattern, null, null);
+    }
+
+    /**
+     * <p>Formats a calendar into a specific pattern.</p>
+     * 
+     * @param calendar  the calendar to format, not null
+     * @param pattern  the pattern to use to format the calendar, not null
+     * @return the formatted calendar
+     * @see FastDateFormat#format(Calendar)
+     * @since 2.4
+     */
+    public static String format(final Calendar calendar, final String pattern) {
+        return format(calendar, pattern, null, null);
+    }
+    
+    /**
+     * <p>Formats a date/time into a specific pattern in a time zone.</p>
+     * 
+     * @param millis  the time expressed in milliseconds
+     * @param pattern  the pattern to use to format the date, not null
+     * @param timeZone  the time zone  to use, may be <code>null</code>
+     * @return the formatted date
+     */
+    public static String format(final long millis, final String pattern, final TimeZone timeZone) {
+        return format(new Date(millis), pattern, timeZone, null);
+    }
+
+    /**
+     * <p>Formats a date/time into a specific pattern in a time zone.</p>
+     * 
+     * @param date  the date to format, not null
+     * @param pattern  the pattern to use to format the date, not null
+     * @param timeZone  the time zone  to use, may be <code>null</code>
+     * @return the formatted date
+     */
+    public static String format(final Date date, final String pattern, final TimeZone timeZone) {
+        return format(date, pattern, timeZone, null);
+    }
+
+    /**
+     * <p>Formats a calendar into a specific pattern in a time zone.</p>
+     * 
+     * @param calendar  the calendar to format, not null
+     * @param pattern  the pattern to use to format the calendar, not null
+     * @param timeZone  the time zone  to use, may be <code>null</code>
+     * @return the formatted calendar
+     * @see FastDateFormat#format(Calendar)
+     * @since 2.4
+     */
+    public static String format(final Calendar calendar, final String pattern, final TimeZone timeZone) {
+        return format(calendar, pattern, timeZone, null);
+    }
+
+    /**
+     * <p>Formats a date/time into a specific pattern in a locale.</p>
+     * 
+     * @param millis  the date to format expressed in milliseconds
+     * @param pattern  the pattern to use to format the date, not null
+     * @param locale  the locale to use, may be <code>null</code>
+     * @return the formatted date
+     */
+    public static String format(final long millis, final String pattern, final Locale locale) {
+        return format(new Date(millis), pattern, null, locale);
+    }
+
+    /**
+     * <p>Formats a date/time into a specific pattern in a locale.</p>
+     * 
+     * @param date  the date to format, not null
+     * @param pattern  the pattern to use to format the date, not null
+     * @param locale  the locale to use, may be <code>null</code>
+     * @return the formatted date
+     */
+    public static String format(final Date date, final String pattern, final Locale locale) {
+        return format(date, pattern, null, locale);
+    }
+
+    /**
+     * <p>Formats a calendar into a specific pattern in a locale.</p>
+     * 
+     * @param calendar  the calendar to format, not null
+     * @param pattern  the pattern to use to format the calendar, not null
+     * @param locale  the locale to use, may be <code>null</code>
+     * @return the formatted calendar
+     * @see FastDateFormat#format(Calendar)
+     * @since 2.4
+     */
+    public static String format(final Calendar calendar, final String pattern, final Locale locale) {
+        return format(calendar, pattern, null, locale);
+    }
+
+    /**
+     * <p>Formats a date/time into a specific pattern in a time zone  and locale.</p>
+     * 
+     * @param millis  the date to format expressed in milliseconds
+     * @param pattern  the pattern to use to format the date, not null
+     * @param timeZone  the time zone  to use, may be <code>null</code>
+     * @param locale  the locale to use, may be <code>null</code>
+     * @return the formatted date
+     */
+    public static String format(final long millis, final String pattern, final TimeZone timeZone, final Locale locale) {
+        return format(new Date(millis), pattern, timeZone, locale);
+    }
+
+    /**
+     * <p>Formats a date/time into a specific pattern in a time zone  and locale.</p>
+     * 
+     * @param date  the date to format, not null
+     * @param pattern  the pattern to use to format the date, not null, not null
+     * @param timeZone  the time zone  to use, may be <code>null</code>
+     * @param locale  the locale to use, may be <code>null</code>
+     * @return the formatted date
+     */
+    public static String format(final Date date, final String pattern, final TimeZone timeZone, final Locale locale) {
+        final FastDateFormat df = FastDateFormat.getInstance(pattern, timeZone, locale);
+        return df.format(date);
+    }
+
+    /**
+     * <p>Formats a calendar into a specific pattern in a time zone  and locale.</p>
+     * 
+     * @param calendar  the calendar to format, not null
+     * @param pattern  the pattern to use to format the calendar, not null
+     * @param timeZone  the time zone  to use, may be <code>null</code>
+     * @param locale  the locale to use, may be <code>null</code>
+     * @return the formatted calendar
+     * @see FastDateFormat#format(Calendar)
+     * @since 2.4
+     */
+    public static String format(final Calendar calendar, final String pattern, final TimeZone timeZone, final Locale locale) {
+        final FastDateFormat df = FastDateFormat.getInstance(pattern, timeZone, locale);
+        return df.format(calendar);
+    }
+
+}

--- a/src/main/java/org/sqlite/date/DateParser.java
+++ b/src/main/java/org/sqlite/date/DateParser.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sqlite.date;
+
+import java.text.ParseException;
+import java.text.ParsePosition;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
+
+/**
+ * <p>DateParser is the "missing" interface for the parsing methods of 
+ * {@link java.text.DateFormat}.</p>
+ * 
+ * @since 3.2
+ */
+public interface DateParser {
+
+    /**
+     * Equivalent to DateFormat.parse(String). 
+     * 
+     * See {@link java.text.DateFormat#parse(String)} for more information. 
+     * @param source A <code>String</code> whose beginning should be parsed. 
+     * @return A <code>Date</code> parsed from the string
+     * @throws ParseException if the beginning of the specified string cannot be parsed.
+     */
+    Date parse(String source) throws ParseException;
+
+    /**
+     * Equivalent to DateFormat.parse(String, ParsePosition). 
+     * 
+     * See {@link java.text.DateFormat#parse(String, ParsePosition)} for more information. 
+     * 
+     * @param source A <code>String</code>, part of which should be parsed.
+     * @param pos A <code>ParsePosition</code> object with index and error index information 
+     * as described above. 
+     * @return A <code>Date</code> parsed from the string. In case of error, returns null. 
+     * @throws NullPointerException if text or pos is null.
+     */
+    Date parse(String source, ParsePosition pos);
+
+    // Accessors
+    //-----------------------------------------------------------------------
+    /**
+     * <p>Get the pattern used by this parser.</p>
+     * 
+     * @return the pattern, {@link java.text.SimpleDateFormat} compatible
+     */
+    String getPattern();
+
+    /**
+     * <p>
+     * Get the time zone used by this parser.
+     * </p>
+     * 
+     * <p>
+     * The default {@link TimeZone} used to create a {@link Date} when the {@link TimeZone} is not specified by
+     * the format pattern.
+     * </p>
+     * 
+     * @return the time zone
+     */
+    TimeZone getTimeZone();
+
+    /**
+     * <p>Get the locale used by this parser.</p>
+     * 
+     * @return the locale
+     */
+    Locale getLocale();
+
+    /**
+     * Parses text from a string to produce a Date.
+     * 
+     * @param source A <code>String</code> whose beginning should be parsed.
+     * @return a <code>java.util.Date</code> object
+     * @throws ParseException if the beginning of the specified string cannot be parsed.
+     * @see java.text.DateFormat#parseObject(String) 
+     */
+    Object parseObject(String source) throws ParseException;
+
+    /**
+     * Parse a date/time string according to the given parse position.
+     * 
+     * @param source A <code>String</code> whose beginning should be parsed.
+     * @param pos the parse position
+     * @return a <code>java.util.Date</code> object
+     * @see java.text.DateFormat#parseObject(String, ParsePosition) 
+     */
+    Object parseObject(String source, ParsePosition pos);
+}

--- a/src/main/java/org/sqlite/date/DatePrinter.java
+++ b/src/main/java/org/sqlite/date/DatePrinter.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sqlite.date;
+
+import java.text.FieldPosition;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
+
+/**
+ * <p>DatePrinter is the "missing" interface for the format methods of 
+ * {@link java.text.DateFormat}.</p>
+ * 
+ * @since 3.2
+ */
+public interface DatePrinter {
+
+    /**
+     * <p>Formats a millisecond {@code long} value.</p>
+     *
+     * @param millis  the millisecond value to format
+     * @return the formatted string
+     * @since 2.1
+     */
+    String format(long millis);
+
+    /**
+     * <p>Formats a {@code Date} object using a {@code GregorianCalendar}.</p>
+     *
+     * @param date  the date to format
+     * @return the formatted string
+     */
+    String format(Date date);
+
+    /**
+     * <p>Formats a {@code Calendar} object.</p>
+     *
+     * @param calendar  the calendar to format
+     * @return the formatted string
+     */
+    String format(Calendar calendar);
+
+    /**
+     * <p>Formats a milliseond {@code long} value into the
+     * supplied {@code StringBuffer}.</p>
+     *
+     * @param millis  the millisecond value to format
+     * @param buf  the buffer to format into
+     * @return the specified string buffer
+     */
+    StringBuffer format(long millis, StringBuffer buf);
+
+    /**
+     * <p>Formats a {@code Date} object into the
+     * supplied {@code StringBuffer} using a {@code GregorianCalendar}.</p>
+     *
+     * @param date  the date to format
+     * @param buf  the buffer to format into
+     * @return the specified string buffer
+     */
+    StringBuffer format(Date date, StringBuffer buf);
+
+    /**
+     * <p>Formats a {@code Calendar} object into the
+     * supplied {@code StringBuffer}.</p>
+     *
+     * @param calendar  the calendar to format
+     * @param buf  the buffer to format into
+     * @return the specified string buffer
+     */
+    StringBuffer format(Calendar calendar, StringBuffer buf);
+
+    // Accessors
+    //-----------------------------------------------------------------------
+    /**
+     * <p>Gets the pattern used by this printer.</p>
+     *
+     * @return the pattern, {@link java.text.SimpleDateFormat} compatible
+     */
+    String getPattern();
+
+    /**
+     * <p>Gets the time zone used by this printer.</p>
+     *
+     * <p>This zone is always used for {@code Date} printing. </p>
+     *
+     * @return the time zone
+     */
+    TimeZone getTimeZone();
+
+    /**
+     * <p>Gets the locale used by this printer.</p>
+     *
+     * @return the locale
+     */
+    Locale getLocale();
+
+    /**
+     * <p>Formats a {@code Date}, {@code Calendar} or
+     * {@code Long} (milliseconds) object.</p>
+     * 
+     * See {@link java.text.DateFormat#format(Object, StringBuffer, FieldPosition)}
+     * 
+     * @param obj  the object to format
+     * @param toAppendTo  the buffer to append to
+     * @param pos  the position - ignored
+     * @return the buffer passed in
+     */
+    StringBuffer format(Object obj, StringBuffer toAppendTo, FieldPosition pos);
+}

--- a/src/main/java/org/sqlite/date/ExceptionUtils.java
+++ b/src/main/java/org/sqlite/date/ExceptionUtils.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sqlite.date;
+
+/**
+ * <p>Provides utilities for manipulating and examining 
+ * <code>Throwable</code> objects.</p>
+ *
+ * @since 1.0
+ */
+public class ExceptionUtils {
+    
+    /**
+     * Throw a checked exception without adding the exception to the throws
+     * clause of the calling method. This method prevents throws clause
+     * pollution and reduces the clutter of "Caused by" exceptions in the
+     * stacktrace.
+     * <p>
+     * The use of this technique may be controversial, but exceedingly useful to
+     * library developers.
+     * <code>
+     *  public int propagateExample { // note that there is no throws clause
+     *      try {
+     *          return invocation(); // throws IOException
+     *      } catch (Exception e) {
+     *          return ExceptionUtils.rethrow(e);  // propagates a checked exception
+     *      }
+     *  }
+     * </code>
+     * <p>
+     * This is an alternative to the more conservative approach of wrapping the
+     * checked exception in a RuntimeException:
+     * <code>
+     *  public int wrapExample { // note that there is no throws clause
+     *      try {
+     *          return invocation(); // throws IOException
+     *      } catch (Error e) {
+     *          throw e;
+     *      } catch (RuntimeException e) {
+     *          throw e;  // wraps a checked exception
+     *      } catch (Exception e) {
+     *          throw new UndeclaredThrowableException(e);  // wraps a checked exception
+     *      }
+     *  }
+     * </code>
+     * <p>
+     * One downside to using this approach is that the java compiler will not
+     * allow invoking code to specify a checked exception in a catch clause
+     * unless there is some code path within the try block that has invoked a
+     * method declared with that checked exception. If the invoking site wishes
+     * to catch the shaded checked exception, it must either invoke the shaded
+     * code through a method re-declaring the desired checked exception, or
+     * catch Exception and use the instanceof operator. Either of these
+     * techniques are required when interacting with non-java jvm code such as
+     * Jyton, Scala, or Groovy, since these languages do not consider any
+     * exceptions as checked.
+     * 
+     * @since 3.5
+     * @see {{@link #wrapAndThrow(Throwable)}
+     *
+     * @param throwable
+     *            The throwable to rethrow.
+     * @return R Never actually returns, this generic type matches any type
+     *         which the calling site requires. "Returning" the results of this
+     *         method, as done in the propagateExample above, will satisfy the
+     *         java compiler requirement that all code paths return a value.
+     * @throws throwable
+     */
+    public static <R> R rethrow(Throwable throwable) {
+        // claim that the typeErasure invocation throws a RuntimeException
+        return ExceptionUtils.<R, RuntimeException> typeErasure(throwable);
+    }
+
+    /**
+     * Claim a Throwable is another Exception type using type erasure. This
+     * hides a checked exception from the java compiler, allowing a checked
+     * exception to be thrown without having the exception in the method's throw
+     * clause.
+     */
+    @SuppressWarnings("unchecked")
+    private static <R, T extends Throwable> R typeErasure(Throwable throwable) throws T {
+        throw (T) throwable;
+    }
+
+}

--- a/src/main/java/org/sqlite/date/FastDateFormat.java
+++ b/src/main/java/org/sqlite/date/FastDateFormat.java
@@ -1,0 +1,603 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sqlite.date;
+
+import java.text.DateFormat;
+import java.text.FieldPosition;
+import java.text.Format;
+import java.text.ParseException;
+import java.text.ParsePosition;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
+
+/**
+ * <p>FastDateFormat is a fast and thread-safe version of
+ * {@link java.text.SimpleDateFormat}.</p>
+ *
+ * <p>To obtain an instance of FastDateFormat, use one of the static factory methods: 
+ * {@link #getInstance(String, TimeZone, Locale)}, {@link #getDateInstance(int, TimeZone, Locale)}, 
+ * {@link #getTimeInstance(int, TimeZone, Locale)}, or {@link #getDateTimeInstance(int, int, TimeZone, Locale)} 
+ * </p>
+ * 
+ * <p>Since FastDateFormat is thread safe, you can use a static member instance:</p>
+ * <code>
+ *   private static final FastDateFormat DATE_FORMATTER = FastDateFormat.getDateTimeInstance(FastDateFormat.LONG, FastDateFormat.SHORT);
+ * </code>
+ * 
+ * <p>This class can be used as a direct replacement to
+ * {@code SimpleDateFormat} in most formatting and parsing situations.
+ * This class is especially useful in multi-threaded server environments.
+ * {@code SimpleDateFormat} is not thread-safe in any JDK version,
+ * nor will it be as Sun have closed the bug/RFE.
+ * </p>
+ *
+ * <p>All patterns are compatible with
+ * SimpleDateFormat (except time zones and some year patterns - see below).</p>
+ *
+ * <p>Since 3.2, FastDateFormat supports parsing as well as printing.</p>
+ *
+ * <p>Java 1.4 introduced a new pattern letter, {@code 'Z'}, to represent
+ * time zones in RFC822 format (eg. {@code +0800} or {@code -1100}).
+ * This pattern letter can be used here (on all JDK versions).</p>
+ *
+ * <p>In addition, the pattern {@code 'ZZ'} has been made to represent
+ * ISO 8601 full format time zones (eg. {@code +08:00} or {@code -11:00}).
+ * This introduces a minor incompatibility with Java 1.4, but at a gain of
+ * useful functionality.</p>
+ *
+ * <p>Javadoc cites for the year pattern: <i>For formatting, if the number of
+ * pattern letters is 2, the year is truncated to 2 digits; otherwise it is
+ * interpreted as a number.</i> Starting with Java 1.7 a pattern of 'Y' or
+ * 'YYY' will be formatted as '2003', while it was '03' in former Java
+ * versions. FastDateFormat implements the behavior of Java 7.</p>
+ *
+ * @since 2.0
+ * @version $Id$
+ */
+public class FastDateFormat extends Format implements DateParser, DatePrinter {
+    /**
+     * Required for serialization support.
+     *
+     * @see java.io.Serializable
+     */
+    private static final long serialVersionUID = 2L;
+
+    /**
+     * FULL locale dependent date or time style.
+     */
+    public static final int FULL = DateFormat.FULL;
+    /**
+     * LONG locale dependent date or time style.
+     */
+    public static final int LONG = DateFormat.LONG;
+    /**
+     * MEDIUM locale dependent date or time style.
+     */
+    public static final int MEDIUM = DateFormat.MEDIUM;
+    /**
+     * SHORT locale dependent date or time style.
+     */
+    public static final int SHORT = DateFormat.SHORT;
+
+    private static final FormatCache<FastDateFormat> cache= new FormatCache<FastDateFormat>() {
+        @Override
+        protected FastDateFormat createInstance(final String pattern, final TimeZone timeZone, final Locale locale) {
+            return new FastDateFormat(pattern, timeZone, locale);
+        }
+    };
+
+    private final FastDatePrinter printer;
+    private final FastDateParser parser;
+
+    //-----------------------------------------------------------------------
+    /**
+     * <p>Gets a formatter instance using the default pattern in the
+     * default locale.</p>
+     *
+     * @return a date/time formatter
+     */
+    public static FastDateFormat getInstance() {
+        return cache.getInstance();
+    }
+
+    /**
+     * <p>Gets a formatter instance using the specified pattern in the
+     * default locale.</p>
+     *
+     * @param pattern  {@link java.text.SimpleDateFormat} compatible
+     *  pattern
+     * @return a pattern based date/time formatter
+     * @throws IllegalArgumentException if pattern is invalid
+     */
+    public static FastDateFormat getInstance(final String pattern) {
+        return cache.getInstance(pattern, null, null);
+    }
+
+    /**
+     * <p>Gets a formatter instance using the specified pattern and
+     * time zone.</p>
+     *
+     * @param pattern  {@link java.text.SimpleDateFormat} compatible
+     *  pattern
+     * @param timeZone  optional time zone, overrides time zone of
+     *  formatted date
+     * @return a pattern based date/time formatter
+     * @throws IllegalArgumentException if pattern is invalid
+     */
+    public static FastDateFormat getInstance(final String pattern, final TimeZone timeZone) {
+        return cache.getInstance(pattern, timeZone, null);
+    }
+
+    /**
+     * <p>Gets a formatter instance using the specified pattern and
+     * locale.</p>
+     *
+     * @param pattern  {@link java.text.SimpleDateFormat} compatible
+     *  pattern
+     * @param locale  optional locale, overrides system locale
+     * @return a pattern based date/time formatter
+     * @throws IllegalArgumentException if pattern is invalid
+     */
+    public static FastDateFormat getInstance(final String pattern, final Locale locale) {
+        return cache.getInstance(pattern, null, locale);
+    }
+
+    /**
+     * <p>Gets a formatter instance using the specified pattern, time zone
+     * and locale.</p>
+     *
+     * @param pattern  {@link java.text.SimpleDateFormat} compatible
+     *  pattern
+     * @param timeZone  optional time zone, overrides time zone of
+     *  formatted date
+     * @param locale  optional locale, overrides system locale
+     * @return a pattern based date/time formatter
+     * @throws IllegalArgumentException if pattern is invalid
+     *  or {@code null}
+     */
+    public static FastDateFormat getInstance(final String pattern, final TimeZone timeZone, final Locale locale) {
+        return cache.getInstance(pattern, timeZone, locale);
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * <p>Gets a date formatter instance using the specified style in the
+     * default time zone and locale.</p>
+     *
+     * @param style  date style: FULL, LONG, MEDIUM, or SHORT
+     * @return a localized standard date formatter
+     * @throws IllegalArgumentException if the Locale has no date
+     *  pattern defined
+     * @since 2.1
+     */
+    public static FastDateFormat getDateInstance(final int style) {
+        return cache.getDateInstance(style, null, null);
+    }
+
+    /**
+     * <p>Gets a date formatter instance using the specified style and
+     * locale in the default time zone.</p>
+     *
+     * @param style  date style: FULL, LONG, MEDIUM, or SHORT
+     * @param locale  optional locale, overrides system locale
+     * @return a localized standard date formatter
+     * @throws IllegalArgumentException if the Locale has no date
+     *  pattern defined
+     * @since 2.1
+     */
+    public static FastDateFormat getDateInstance(final int style, final Locale locale) {
+        return cache.getDateInstance(style, null, locale);
+    }
+
+    /**
+     * <p>Gets a date formatter instance using the specified style and
+     * time zone in the default locale.</p>
+     *
+     * @param style  date style: FULL, LONG, MEDIUM, or SHORT
+     * @param timeZone  optional time zone, overrides time zone of
+     *  formatted date
+     * @return a localized standard date formatter
+     * @throws IllegalArgumentException if the Locale has no date
+     *  pattern defined
+     * @since 2.1
+     */
+    public static FastDateFormat getDateInstance(final int style, final TimeZone timeZone) {
+        return cache.getDateInstance(style, timeZone, null);
+    }
+
+    /**
+     * <p>Gets a date formatter instance using the specified style, time
+     * zone and locale.</p>
+     *
+     * @param style  date style: FULL, LONG, MEDIUM, or SHORT
+     * @param timeZone  optional time zone, overrides time zone of
+     *  formatted date
+     * @param locale  optional locale, overrides system locale
+     * @return a localized standard date formatter
+     * @throws IllegalArgumentException if the Locale has no date
+     *  pattern defined
+     */
+    public static FastDateFormat getDateInstance(final int style, final TimeZone timeZone, final Locale locale) {
+        return cache.getDateInstance(style, timeZone, locale);
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * <p>Gets a time formatter instance using the specified style in the
+     * default time zone and locale.</p>
+     *
+     * @param style  time style: FULL, LONG, MEDIUM, or SHORT
+     * @return a localized standard time formatter
+     * @throws IllegalArgumentException if the Locale has no time
+     *  pattern defined
+     * @since 2.1
+     */
+    public static FastDateFormat getTimeInstance(final int style) {
+        return cache.getTimeInstance(style, null, null);
+    }
+
+    /**
+     * <p>Gets a time formatter instance using the specified style and
+     * locale in the default time zone.</p>
+     *
+     * @param style  time style: FULL, LONG, MEDIUM, or SHORT
+     * @param locale  optional locale, overrides system locale
+     * @return a localized standard time formatter
+     * @throws IllegalArgumentException if the Locale has no time
+     *  pattern defined
+     * @since 2.1
+     */
+    public static FastDateFormat getTimeInstance(final int style, final Locale locale) {
+        return cache.getTimeInstance(style, null, locale);
+    }
+
+    /**
+     * <p>Gets a time formatter instance using the specified style and
+     * time zone in the default locale.</p>
+     *
+     * @param style  time style: FULL, LONG, MEDIUM, or SHORT
+     * @param timeZone  optional time zone, overrides time zone of
+     *  formatted time
+     * @return a localized standard time formatter
+     * @throws IllegalArgumentException if the Locale has no time
+     *  pattern defined
+     * @since 2.1
+     */
+    public static FastDateFormat getTimeInstance(final int style, final TimeZone timeZone) {
+        return cache.getTimeInstance(style, timeZone, null);
+    }
+
+    /**
+     * <p>Gets a time formatter instance using the specified style, time
+     * zone and locale.</p>
+     *
+     * @param style  time style: FULL, LONG, MEDIUM, or SHORT
+     * @param timeZone  optional time zone, overrides time zone of
+     *  formatted time
+     * @param locale  optional locale, overrides system locale
+     * @return a localized standard time formatter
+     * @throws IllegalArgumentException if the Locale has no time
+     *  pattern defined
+     */
+    public static FastDateFormat getTimeInstance(final int style, final TimeZone timeZone, final Locale locale) {
+        return cache.getTimeInstance(style, timeZone, locale);
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * <p>Gets a date/time formatter instance using the specified style
+     * in the default time zone and locale.</p>
+     *
+     * @param dateStyle  date style: FULL, LONG, MEDIUM, or SHORT
+     * @param timeStyle  time style: FULL, LONG, MEDIUM, or SHORT
+     * @return a localized standard date/time formatter
+     * @throws IllegalArgumentException if the Locale has no date/time
+     *  pattern defined
+     * @since 2.1
+     */
+    public static FastDateFormat getDateTimeInstance(final int dateStyle, final int timeStyle) {
+        return cache.getDateTimeInstance(dateStyle, timeStyle, null, null);
+    }
+
+    /**
+     * <p>Gets a date/time formatter instance using the specified style and
+     * locale in the default time zone.</p>
+     *
+     * @param dateStyle  date style: FULL, LONG, MEDIUM, or SHORT
+     * @param timeStyle  time style: FULL, LONG, MEDIUM, or SHORT
+     * @param locale  optional locale, overrides system locale
+     * @return a localized standard date/time formatter
+     * @throws IllegalArgumentException if the Locale has no date/time
+     *  pattern defined
+     * @since 2.1
+     */
+    public static FastDateFormat getDateTimeInstance(final int dateStyle, final int timeStyle, final Locale locale) {
+        return cache.getDateTimeInstance(dateStyle, timeStyle, null, locale);
+    }
+
+    /**
+     * <p>Gets a date/time formatter instance using the specified style and
+     * time zone in the default locale.</p>
+     *
+     * @param dateStyle  date style: FULL, LONG, MEDIUM, or SHORT
+     * @param timeStyle  time style: FULL, LONG, MEDIUM, or SHORT
+     * @param timeZone  optional time zone, overrides time zone of
+     *  formatted date
+     * @return a localized standard date/time formatter
+     * @throws IllegalArgumentException if the Locale has no date/time
+     *  pattern defined
+     * @since 2.1
+     */
+    public static FastDateFormat getDateTimeInstance(final int dateStyle, final int timeStyle, final TimeZone timeZone) {
+        return getDateTimeInstance(dateStyle, timeStyle, timeZone, null);
+    }
+    /**
+     * <p>Gets a date/time formatter instance using the specified style,
+     * time zone and locale.</p>
+     *
+     * @param dateStyle  date style: FULL, LONG, MEDIUM, or SHORT
+     * @param timeStyle  time style: FULL, LONG, MEDIUM, or SHORT
+     * @param timeZone  optional time zone, overrides time zone of
+     *  formatted date
+     * @param locale  optional locale, overrides system locale
+     * @return a localized standard date/time formatter
+     * @throws IllegalArgumentException if the Locale has no date/time
+     *  pattern defined
+     */
+    public static FastDateFormat getDateTimeInstance(
+            final int dateStyle, final int timeStyle, final TimeZone timeZone, final Locale locale) {
+        return cache.getDateTimeInstance(dateStyle, timeStyle, timeZone, locale);
+    }
+
+    // Constructor
+    //-----------------------------------------------------------------------
+    /**
+     * <p>Constructs a new FastDateFormat.</p>
+     *
+     * @param pattern  {@link java.text.SimpleDateFormat} compatible pattern
+     * @param timeZone  non-null time zone to use
+     * @param locale  non-null locale to use
+     * @throws NullPointerException if pattern, timeZone, or locale is null.
+     */
+    protected FastDateFormat(final String pattern, final TimeZone timeZone, final Locale locale) {
+        this(pattern, timeZone, locale, null);
+    }
+
+    // Constructor
+    //-----------------------------------------------------------------------
+    /**
+     * <p>Constructs a new FastDateFormat.</p>
+     *
+     * @param pattern  {@link java.text.SimpleDateFormat} compatible pattern
+     * @param timeZone  non-null time zone to use
+     * @param locale  non-null locale to use
+     * @param centuryStart The start of the 100 year period to use as the "default century" for 2 digit year parsing.  If centuryStart is null, defaults to now - 80 years
+     * @throws NullPointerException if pattern, timeZone, or locale is null.
+     */
+    protected FastDateFormat(final String pattern, final TimeZone timeZone, final Locale locale, final Date centuryStart) {
+        printer= new FastDatePrinter(pattern, timeZone, locale);
+        parser= new FastDateParser(pattern, timeZone, locale, centuryStart);
+    }
+
+    // Format methods
+    //-----------------------------------------------------------------------
+    /**
+     * <p>Formats a {@code Date}, {@code Calendar} or
+     * {@code Long} (milliseconds) object.</p>
+     *
+     * @param obj  the object to format
+     * @param toAppendTo  the buffer to append to
+     * @param pos  the position - ignored
+     * @return the buffer passed in
+     */
+    @Override
+    public StringBuffer format(final Object obj, final StringBuffer toAppendTo, final FieldPosition pos) {
+        return printer.format(obj, toAppendTo, pos);
+    }
+
+    /**
+     * <p>Formats a millisecond {@code long} value.</p>
+     *
+     * @param millis  the millisecond value to format
+     * @return the formatted string
+     * @since 2.1
+     */
+    public String format(final long millis) {
+        return printer.format(millis);
+    }
+
+    /**
+     * <p>Formats a {@code Date} object using a {@code GregorianCalendar}.</p>
+     *
+     * @param date  the date to format
+     * @return the formatted string
+     */
+    public String format(final Date date) {
+        return printer.format(date);
+    }
+
+    /**
+     * <p>Formats a {@code Calendar} object.</p>
+     *
+     * @param calendar  the calendar to format
+     * @return the formatted string
+     */
+    public String format(final Calendar calendar) {
+        return printer.format(calendar);
+    }
+
+    /**
+     * <p>Formats a millisecond {@code long} value into the
+     * supplied {@code StringBuffer}.</p>
+     *
+     * @param millis  the millisecond value to format
+     * @param buf  the buffer to format into
+     * @return the specified string buffer
+     * @since 2.1
+     */
+    public StringBuffer format(final long millis, final StringBuffer buf) {
+        return printer.format(millis, buf);
+    }
+
+    /**
+     * <p>Formats a {@code Date} object into the
+     * supplied {@code StringBuffer} using a {@code GregorianCalendar}.</p>
+     *
+     * @param date  the date to format
+     * @param buf  the buffer to format into
+     * @return the specified string buffer
+     */
+    public StringBuffer format(final Date date, final StringBuffer buf) {
+        return printer.format(date, buf);
+    }
+
+    /**
+     * <p>Formats a {@code Calendar} object into the
+     * supplied {@code StringBuffer}.</p>
+     *
+     * @param calendar  the calendar to format
+     * @param buf  the buffer to format into
+     * @return the specified string buffer
+     */
+    public StringBuffer format(final Calendar calendar, final StringBuffer buf) {
+        return printer.format(calendar, buf);
+    }
+
+    // Parsing
+    //-----------------------------------------------------------------------
+
+
+    /* (non-Javadoc)
+     * @see DateParser#parse(java.lang.String)
+     */
+    public Date parse(final String source) throws ParseException {
+        return parser.parse(source);
+    }
+
+    /* (non-Javadoc)
+     * @see DateParser#parse(java.lang.String, java.text.ParsePosition)
+     */
+    public Date parse(final String source, final ParsePosition pos) {
+            return parser.parse(source, pos);
+    }
+
+    /* (non-Javadoc)
+     * @see java.text.Format#parseObject(java.lang.String, java.text.ParsePosition)
+     */
+    public Object parseObject(final String source, final ParsePosition pos) {
+        return parser.parseObject(source, pos);
+    }
+
+    // Accessors
+    //-----------------------------------------------------------------------
+    /**
+     * <p>Gets the pattern used by this formatter.</p>
+     *
+     * @return the pattern, {@link java.text.SimpleDateFormat} compatible
+     */
+    public String getPattern() {
+        return printer.getPattern();
+    }
+
+    /**
+     * <p>Gets the time zone used by this formatter.</p>
+     *
+     * <p>This zone is always used for {@code Date} formatting. </p>
+     *
+     * @return the time zone
+     */
+    public TimeZone getTimeZone() {
+        return printer.getTimeZone();
+    }
+
+    /**
+     * <p>Gets the locale used by this formatter.</p>
+     *
+     * @return the locale
+     */
+    public Locale getLocale() {
+        return printer.getLocale();
+    }
+
+    /**
+     * <p>Gets an estimate for the maximum string length that the
+     * formatter will produce.</p>
+     *
+     * <p>The actual formatted length will almost always be less than or
+     * equal to this amount.</p>
+     *
+     * @return the maximum formatted length
+     */
+    public int getMaxLengthEstimate() {
+        return printer.getMaxLengthEstimate();
+    }
+
+    // Basics
+    //-----------------------------------------------------------------------
+    /**
+     * <p>Compares two objects for equality.</p>
+     *
+     * @param obj  the object to compare to
+     * @return {@code true} if equal
+     */
+    @Override
+    public boolean equals(final Object obj) {
+        if (obj instanceof FastDateFormat == false) {
+            return false;
+        }
+        final FastDateFormat other = (FastDateFormat) obj;
+        // no need to check parser, as it has same invariants as printer
+        return printer.equals(other.printer);
+    }
+
+    /**
+     * <p>Returns a hashcode compatible with equals.</p>
+     *
+     * @return a hashcode compatible with equals
+     */
+    @Override
+    public int hashCode() {
+        return printer.hashCode();
+    }
+
+    /**
+     * <p>Gets a debugging string version of this formatter.</p>
+     *
+     * @return a debugging string
+     */
+    @Override
+    public String toString() {
+        return "FastDateFormat[" + printer.getPattern() + "," + printer.getLocale() + "," + printer.getTimeZone().getID() + "]";
+    }
+
+
+    /**
+     * <p>Performs the formatting by applying the rules to the
+     * specified calendar.</p>
+     *
+     * @param calendar  the calendar to format
+     * @param buf  the buffer to format into
+     * @return the specified string buffer
+     */
+    protected StringBuffer applyRules(final Calendar calendar, final StringBuffer buf) {
+        return printer.applyRules(calendar, buf);
+    }
+
+
+}

--- a/src/main/java/org/sqlite/date/FastDateParser.java
+++ b/src/main/java/org/sqlite/date/FastDateParser.java
@@ -1,0 +1,924 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sqlite.date;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.Serializable;
+import java.text.DateFormatSymbols;
+import java.text.ParseException;
+import java.text.ParsePosition;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TimeZone;
+import java.util.TreeMap;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * <p>FastDateParser is a fast and thread-safe version of
+ * {@link java.text.SimpleDateFormat}.</p>
+ *
+ * <p>To obtain a proxy to a FastDateParser, use {@link FastDateFormat#getInstance(String, TimeZone, Locale)} 
+ * or another variation of the factory methods of {@link FastDateFormat}.</p>
+ * 
+ * <p>Since FastDateParser is thread safe, you can use a static member instance:</p>
+ * <code>
+ *     private static final DateParser DATE_PARSER = FastDateFormat.getInstance("yyyy-MM-dd");
+ * </code>
+ * 
+ * <p>This class can be used as a direct replacement for
+ * <code>SimpleDateFormat</code> in most parsing situations.
+ * This class is especially useful in multi-threaded server environments.
+ * <code>SimpleDateFormat</code> is not thread-safe in any JDK version,
+ * nor will it be as Sun has closed the
+ * <a href="http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=4228335">bug</a>/RFE.
+ * </p>
+ *
+ * <p>Only parsing is supported by this class, but all patterns are compatible with
+ * SimpleDateFormat.</p>
+ *
+ * <p>The class operates in lenient mode, so for example a time of 90 minutes is treated as 1 hour 30 minutes.</p>
+ *
+ * <p>Timing tests indicate this class is as about as fast as SimpleDateFormat
+ * in single thread applications and about 25% faster in multi-thread applications.</p>
+ *
+ * @version $Id$
+ * @since 3.2
+ * @see FastDatePrinter
+ */
+public class FastDateParser implements DateParser, Serializable {
+    /**
+     * Required for serialization support.
+     *
+     * @see java.io.Serializable
+     */
+    private static final long serialVersionUID = 2L;
+
+    static final Locale JAPANESE_IMPERIAL = new Locale("ja","JP","JP");
+
+    // defining fields
+    private final String pattern;
+    private final TimeZone timeZone;
+    private final Locale locale;
+    private final int century;
+    private final int startYear;
+
+    // derived fields
+    private transient Pattern parsePattern;
+    private transient Strategy[] strategies;
+
+    // dynamic fields to communicate with Strategy
+    private transient String currentFormatField;
+    private transient Strategy nextStrategy;
+
+    /**
+     * <p>Constructs a new FastDateParser.</p>
+     * 
+     * Use {@link FastDateFormat#getInstance(String, TimeZone, Locale)} or another variation of the 
+     * factory methods of {@link FastDateFormat} to get a cached FastDateParser instance.
+     *
+     * @param pattern non-null {@link java.text.SimpleDateFormat} compatible
+     *  pattern
+     * @param timeZone non-null time zone to use
+     * @param locale non-null locale
+     */
+    protected FastDateParser(final String pattern, final TimeZone timeZone, final Locale locale) {
+        this(pattern, timeZone, locale, null);
+    }
+
+    /**
+     * <p>Constructs a new FastDateParser.</p>
+     *
+     * @param pattern non-null {@link java.text.SimpleDateFormat} compatible
+     *  pattern
+     * @param timeZone non-null time zone to use
+     * @param locale non-null locale
+     * @param centuryStart The start of the century for 2 digit year parsing
+     *
+     * @since 3.3
+     */
+    protected FastDateParser(final String pattern, final TimeZone timeZone, final Locale locale, final Date centuryStart) {
+        this.pattern = pattern;
+        this.timeZone = timeZone;
+        this.locale = locale;
+
+        final Calendar definingCalendar = Calendar.getInstance(timeZone, locale);
+        int centuryStartYear;
+        if(centuryStart!=null) {
+            definingCalendar.setTime(centuryStart);
+            centuryStartYear= definingCalendar.get(Calendar.YEAR);
+        }
+        else if(locale.equals(JAPANESE_IMPERIAL)) {
+            centuryStartYear= 0;
+        }
+        else {
+            // from 80 years ago to 20 years from now
+            definingCalendar.setTime(new Date());
+            centuryStartYear= definingCalendar.get(Calendar.YEAR)-80;
+        }
+        century= centuryStartYear / 100 * 100;
+        startYear= centuryStartYear - century;
+
+        init(definingCalendar);
+    }
+
+    /**
+     * Initialize derived fields from defining fields.
+     * This is called from constructor and from readObject (de-serialization)
+     *
+     * @param definingCalendar the {@link java.util.Calendar} instance used to initialize this FastDateParser
+     */
+    private void init(final Calendar definingCalendar) {
+
+        final StringBuilder regex= new StringBuilder();
+        final List<Strategy> collector = new ArrayList<Strategy>();
+
+        final Matcher patternMatcher= formatPattern.matcher(pattern);
+        if(!patternMatcher.lookingAt()) {
+            throw new IllegalArgumentException(
+                    "Illegal pattern character '" + pattern.charAt(patternMatcher.regionStart()) + "'");
+        }
+
+        currentFormatField= patternMatcher.group();
+        Strategy currentStrategy= getStrategy(currentFormatField, definingCalendar);
+        for(;;) {
+            patternMatcher.region(patternMatcher.end(), patternMatcher.regionEnd());
+            if(!patternMatcher.lookingAt()) {
+                nextStrategy = null;
+                break;
+            }
+            final String nextFormatField= patternMatcher.group();
+            nextStrategy = getStrategy(nextFormatField, definingCalendar);
+            if(currentStrategy.addRegex(this, regex)) {
+                collector.add(currentStrategy);
+            }
+            currentFormatField= nextFormatField;
+            currentStrategy= nextStrategy;
+        }
+        if (patternMatcher.regionStart() != patternMatcher.regionEnd()) {
+            throw new IllegalArgumentException("Failed to parse \""+pattern+"\" ; gave up at index "+patternMatcher.regionStart());
+        }
+        if(currentStrategy.addRegex(this, regex)) {
+            collector.add(currentStrategy);
+        }
+        currentFormatField= null;
+        strategies= collector.toArray(new Strategy[collector.size()]);
+        parsePattern= Pattern.compile(regex.toString());
+    }
+
+    // Accessors
+    //-----------------------------------------------------------------------
+    /* (non-Javadoc)
+     * @see org.apache.commons.lang3.time.DateParser#getPattern()
+     */
+    public String getPattern() {
+        return pattern;
+    }
+
+    /* (non-Javadoc)
+     * @see org.apache.commons.lang3.time.DateParser#getTimeZone()
+     */
+    public TimeZone getTimeZone() {
+        return timeZone;
+    }
+
+    /* (non-Javadoc)
+     * @see org.apache.commons.lang3.time.DateParser#getLocale()
+     */
+    public Locale getLocale() {
+        return locale;
+    }
+
+    /**
+     * Returns the generated pattern (for testing purposes).
+     *
+     * @return the generated pattern
+     */
+    Pattern getParsePattern() {
+        return parsePattern;
+    }
+
+    // Basics
+    //-----------------------------------------------------------------------
+    /**
+     * <p>Compare another object for equality with this object.</p>
+     *
+     * @param obj  the object to compare to
+     * @return <code>true</code>if equal to this instance
+     */
+    @Override
+    public boolean equals(final Object obj) {
+        if (! (obj instanceof FastDateParser) ) {
+            return false;
+        }
+        final FastDateParser other = (FastDateParser) obj;
+        return pattern.equals(other.pattern)
+            && timeZone.equals(other.timeZone)
+            && locale.equals(other.locale);
+    }
+
+    /**
+     * <p>Return a hashcode compatible with equals.</p>
+     *
+     * @return a hashcode compatible with equals
+     */
+    @Override
+    public int hashCode() {
+        return pattern.hashCode() + 13 * (timeZone.hashCode() + 13 * locale.hashCode());
+    }
+
+    /**
+     * <p>Get a string version of this formatter.</p>
+     *
+     * @return a debugging string
+     */
+    @Override
+    public String toString() {
+        return "FastDateParser[" + pattern + "," + locale + "," + timeZone.getID() + "]";
+    }
+
+    // Serializing
+    //-----------------------------------------------------------------------
+    /**
+     * Create the object after serialization. This implementation reinitializes the
+     * transient properties.
+     *
+     * @param in ObjectInputStream from which the object is being deserialized.
+     * @throws IOException if there is an IO issue.
+     * @throws ClassNotFoundException if a class cannot be found.
+     */
+    private void readObject(final ObjectInputStream in) throws IOException, ClassNotFoundException {
+        in.defaultReadObject();
+
+        final Calendar definingCalendar = Calendar.getInstance(timeZone, locale);
+        init(definingCalendar);
+    }
+
+    /* (non-Javadoc)
+     * @see org.apache.commons.lang3.time.DateParser#parseObject(java.lang.String)
+     */
+    public Object parseObject(final String source) throws ParseException {
+        return parse(source);
+    }
+
+    /* (non-Javadoc)
+     * @see org.apache.commons.lang3.time.DateParser#parse(java.lang.String)
+     */
+    public Date parse(final String source) throws ParseException {
+        final Date date= parse(source, new ParsePosition(0));
+        if(date==null) {
+            // Add a note re supported date range
+            if (locale.equals(JAPANESE_IMPERIAL)) {
+                throw new ParseException(
+                        "(The " +locale + " locale does not support dates before 1868 AD)\n" +
+                                "Unparseable date: \""+source+"\" does not match "+parsePattern.pattern(), 0);
+            }
+            throw new ParseException("Unparseable date: \""+source+"\" does not match "+parsePattern.pattern(), 0);
+        }
+        return date;
+    }
+
+    /* (non-Javadoc)
+     * @see org.apache.commons.lang3.time.DateParser#parseObject(java.lang.String, java.text.ParsePosition)
+     */
+    public Object parseObject(final String source, final ParsePosition pos) {
+        return parse(source, pos);
+    }
+
+    /**
+     * This implementation updates the ParsePosition if the parse succeeeds.
+     * However, unlike the method {@link java.text.SimpleDateFormat#parse(String, ParsePosition)}
+     * it is not able to set the error Index - i.e. {@link ParsePosition#getErrorIndex()} -  if the parse fails.
+     * <p>
+     * To determine if the parse has succeeded, the caller must check if the current parse position
+     * given by {@link ParsePosition#getIndex()} has been updated. If the input buffer has been fully
+     * parsed, then the index will point to just after the end of the input buffer.
+     *
+     * @see org.apache.commons.lang3.time.DateParser#parse(java.lang.String, java.text.ParsePosition)
+     * {@inheritDoc}
+     */
+    public Date parse(final String source, final ParsePosition pos) {
+        final int offset= pos.getIndex();
+        final Matcher matcher= parsePattern.matcher(source.substring(offset));
+        if(!matcher.lookingAt()) {
+            return null;
+        }
+        // timing tests indicate getting new instance is 19% faster than cloning
+        final Calendar cal= Calendar.getInstance(timeZone, locale);
+        cal.clear();
+
+        for(int i=0; i<strategies.length;) {
+            final Strategy strategy= strategies[i++];
+            strategy.setCalendar(this, cal, matcher.group(i));
+        }
+        pos.setIndex(offset+matcher.end());
+        return cal.getTime();
+    }
+
+    // Support for strategies
+    //-----------------------------------------------------------------------
+
+    /**
+     * Escape constant fields into regular expression
+     * @param regex The destination regex
+     * @param value The source field
+     * @param unquote If true, replace two success quotes ('') with single quote (')
+     * @return The <code>StringBuilder</code>
+     */
+    private static StringBuilder escapeRegex(final StringBuilder regex, final String value, final boolean unquote) {
+        regex.append("\\Q");
+        for(int i= 0; i<value.length(); ++i) {
+            char c= value.charAt(i);
+            switch(c) {
+            case '\'':
+                if(unquote) {
+                    if(++i==value.length()) {
+                        return regex;
+                    }
+                    c= value.charAt(i);
+                }
+                break;
+            case '\\':
+                if(++i==value.length()) {
+                    break;
+                }
+                /*
+                 * If we have found \E, we replace it with \E\\E\Q, i.e. we stop the quoting,
+                 * quote the \ in \E, then restart the quoting.
+                 *
+                 * Otherwise we just output the two characters.
+                 * In each case the initial \ needs to be output and the final char is done at the end
+                 */
+                regex.append(c); // we always want the original \
+                c = value.charAt(i); // Is it followed by E ?
+                if (c == 'E') { // \E detected
+                  regex.append("E\\\\E\\"); // see comment above
+                  c = 'Q'; // appended below
+                }
+                break;
+            default:
+                break;
+            }
+            regex.append(c);
+        }
+        regex.append("\\E");
+        return regex;
+    }
+
+
+    /**
+     * Get the short and long values displayed for a field
+     * @param field The field of interest
+     * @param definingCalendar The calendar to obtain the short and long values
+     * @param locale The locale of display names
+     * @return A Map of the field key / value pairs
+     */
+    private static Map<String, Integer> getDisplayNames(final int field, final Calendar definingCalendar, final Locale locale) {
+        return definingCalendar.getDisplayNames(field, Calendar.ALL_STYLES, locale);
+    }
+
+    /**
+     * Adjust dates to be within appropriate century
+     * @param twoDigitYear The year to adjust
+     * @return A value between centuryStart(inclusive) to centuryStart+100(exclusive)
+     */
+    private int adjustYear(final int twoDigitYear) {
+        final int trial= century + twoDigitYear;
+        return twoDigitYear>=startYear ?trial :trial+100;
+    }
+
+    /**
+     * Is the next field a number?
+     * @return true, if next field will be a number
+     */
+    boolean isNextNumber() {
+        return nextStrategy!=null && nextStrategy.isNumber();
+    }
+
+    /**
+     * What is the width of the current field?
+     * @return The number of characters in the current format field
+     */
+    int getFieldWidth() {
+        return currentFormatField.length();
+    }
+
+    /**
+     * A strategy to parse a single field from the parsing pattern
+     */
+    private static abstract class Strategy {
+        
+        /**
+         * Is this field a number?
+         * The default implementation returns false.
+         *
+         * @return true, if field is a number
+         */
+        boolean isNumber() {
+            return false;
+        }
+        
+        /**
+         * Set the Calendar with the parsed field.
+         *
+         * The default implementation does nothing.
+         *
+         * @param parser The parser calling this strategy
+         * @param cal The <code>Calendar</code> to set
+         * @param value The parsed field to translate and set in cal
+         */
+        void setCalendar(final FastDateParser parser, final Calendar cal, final String value) {
+
+        }
+        
+        /**
+         * Generate a <code>Pattern</code> regular expression to the <code>StringBuilder</code>
+         * which will accept this field
+         * @param parser The parser calling this strategy
+         * @param regex The <code>StringBuilder</code> to append to
+         * @return true, if this field will set the calendar;
+         * false, if this field is a constant value
+         */
+        abstract boolean addRegex(FastDateParser parser, StringBuilder regex);
+
+    }
+
+    /**
+     * A <code>Pattern</code> to parse the user supplied SimpleDateFormat pattern
+     */
+    private static final Pattern formatPattern= Pattern.compile(
+            "D+|E+|F+|G+|H+|K+|M+|S+|W+|X+|Z+|a+|d+|h+|k+|m+|s+|w+|y+|z+|''|'[^']++(''[^']*+)*+'|[^'A-Za-z]++");
+
+    /**
+     * Obtain a Strategy given a field from a SimpleDateFormat pattern
+     * @param formatField A sub-sequence of the SimpleDateFormat pattern
+     * @param definingCalendar The calendar to obtain the short and long values
+     * @return The Strategy that will handle parsing for the field
+     */
+    private Strategy getStrategy(final String formatField, final Calendar definingCalendar) {
+        switch(formatField.charAt(0)) {
+        case '\'':
+            if(formatField.length()>2) {
+                return new CopyQuotedStrategy(formatField.substring(1, formatField.length()-1));
+            }
+            //$FALL-THROUGH$
+        default:
+            return new CopyQuotedStrategy(formatField);
+        case 'D':
+            return DAY_OF_YEAR_STRATEGY;
+        case 'E':
+            return getLocaleSpecificStrategy(Calendar.DAY_OF_WEEK, definingCalendar);
+        case 'F':
+            return DAY_OF_WEEK_IN_MONTH_STRATEGY;
+        case 'G':
+            return getLocaleSpecificStrategy(Calendar.ERA, definingCalendar);
+        case 'H':  // Hour in day (0-23)
+            return HOUR_OF_DAY_STRATEGY;
+        case 'K':  // Hour in am/pm (0-11) 
+            return HOUR_STRATEGY;
+        case 'M':
+            return formatField.length()>=3 ?getLocaleSpecificStrategy(Calendar.MONTH, definingCalendar) :NUMBER_MONTH_STRATEGY;
+        case 'S':
+            return MILLISECOND_STRATEGY;
+        case 'W':
+            return WEEK_OF_MONTH_STRATEGY;
+        case 'a':
+            return getLocaleSpecificStrategy(Calendar.AM_PM, definingCalendar);
+        case 'd':
+            return DAY_OF_MONTH_STRATEGY;
+        case 'h':  // Hour in am/pm (1-12), i.e. midday/midnight is 12, not 0
+            return HOUR12_STRATEGY;
+        case 'k':  // Hour in day (1-24), i.e. midnight is 24, not 0
+            return HOUR24_OF_DAY_STRATEGY;
+        case 'm':
+            return MINUTE_STRATEGY;
+        case 's':
+            return SECOND_STRATEGY;
+        case 'w':
+            return WEEK_OF_YEAR_STRATEGY;
+        case 'y':
+            return formatField.length()>2 ?LITERAL_YEAR_STRATEGY :ABBREVIATED_YEAR_STRATEGY;
+        case 'X':
+            return ISO8601TimeZoneStrategy.getStrategy(formatField.length());
+        case 'Z':
+            if (formatField.equals("ZZ")) {
+                return ISO_8601_STRATEGY;
+            }
+            //$FALL-THROUGH$
+        case 'z':
+            return getLocaleSpecificStrategy(Calendar.ZONE_OFFSET, definingCalendar);
+        }
+    }
+
+    @SuppressWarnings("unchecked") // OK because we are creating an array with no entries
+    private static final ConcurrentMap<Locale, Strategy>[] caches = new ConcurrentMap[Calendar.FIELD_COUNT];
+
+    /**
+     * Get a cache of Strategies for a particular field
+     * @param field The Calendar field
+     * @return a cache of Locale to Strategy
+     */
+    private static ConcurrentMap<Locale, Strategy> getCache(final int field) {
+        synchronized(caches) {
+            if(caches[field]==null) {
+                caches[field]= new ConcurrentHashMap<Locale,Strategy>(3);
+            }
+            return caches[field];
+        }
+    }
+
+    /**
+     * Construct a Strategy that parses a Text field
+     * @param field The Calendar field
+     * @param definingCalendar The calendar to obtain the short and long values
+     * @return a TextStrategy for the field and Locale
+     */
+    private Strategy getLocaleSpecificStrategy(final int field, final Calendar definingCalendar) {
+        final ConcurrentMap<Locale,Strategy> cache = getCache(field);
+        Strategy strategy= cache.get(locale);
+        if(strategy==null) {
+            strategy= field==Calendar.ZONE_OFFSET
+                    ? new TimeZoneStrategy(locale)
+                    : new CaseInsensitiveTextStrategy(field, definingCalendar, locale);
+            final Strategy inCache= cache.putIfAbsent(locale, strategy);
+            if(inCache!=null) {
+                return inCache;
+            }
+        }
+        return strategy;
+    }
+
+    /**
+     * A strategy that copies the static or quoted field in the parsing pattern
+     */
+    private static class CopyQuotedStrategy extends Strategy {
+        private final String formatField;
+
+        /**
+         * Construct a Strategy that ensures the formatField has literal text
+         * @param formatField The literal text to match
+         */
+        CopyQuotedStrategy(final String formatField) {
+            this.formatField= formatField;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        boolean isNumber() {
+            char c= formatField.charAt(0);
+            if(c=='\'') {
+                c= formatField.charAt(1);
+            }
+            return Character.isDigit(c);
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        boolean addRegex(final FastDateParser parser, final StringBuilder regex) {
+            escapeRegex(regex, formatField, true);
+            return false;
+        }
+    }
+
+    /**
+     * A strategy that handles a text field in the parsing pattern
+     */
+     private static class CaseInsensitiveTextStrategy extends Strategy {
+        private final int field;
+        private final Locale locale;
+        private final Map<String, Integer> lKeyValues;
+
+        /**
+         * Construct a Strategy that parses a Text field
+         * @param field  The Calendar field
+         * @param definingCalendar  The Calendar to use
+         * @param locale  The Locale to use
+         */
+        CaseInsensitiveTextStrategy(final int field, final Calendar definingCalendar, final Locale locale) {
+            this.field= field;
+            this.locale= locale;
+            final Map<String, Integer> keyValues = getDisplayNames(field, definingCalendar, locale);
+            this.lKeyValues= new HashMap<String,Integer>();
+
+            for(final Map.Entry<String, Integer> entry : keyValues.entrySet()) {
+                lKeyValues.put(entry.getKey().toLowerCase(locale), entry.getValue());
+            }
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        boolean addRegex(final FastDateParser parser, final StringBuilder regex) {
+            regex.append("((?iu)");
+            for(final String textKeyValue : lKeyValues.keySet()) {
+                escapeRegex(regex, textKeyValue, false).append('|');
+            }
+            regex.setCharAt(regex.length()-1, ')');
+            return true;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        void setCalendar(final FastDateParser parser, final Calendar cal, final String value) {
+            final Integer iVal = lKeyValues.get(value.toLowerCase(locale));
+            if(iVal == null) {
+                final StringBuilder sb= new StringBuilder(value);
+                sb.append(" not in (");
+                for(final String textKeyValue : lKeyValues.keySet()) {
+                    sb.append(textKeyValue).append(' ');
+                }
+                sb.setCharAt(sb.length()-1, ')');
+                throw new IllegalArgumentException(sb.toString());
+            }
+            cal.set(field, iVal.intValue());
+        }
+    }
+
+
+    /**
+     * A strategy that handles a number field in the parsing pattern
+     */
+    private static class NumberStrategy extends Strategy {
+        private final int field;
+
+        /**
+         * Construct a Strategy that parses a Number field
+         * @param field The Calendar field
+         */
+        NumberStrategy(final int field) {
+             this.field= field;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        boolean isNumber() {
+            return true;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        boolean addRegex(final FastDateParser parser, final StringBuilder regex) {
+            // See LANG-954: We use {Nd} rather than {IsNd} because Android does not support the Is prefix
+            if(parser.isNextNumber()) {
+                regex.append("(\\p{Nd}{").append(parser.getFieldWidth()).append("}+)");
+            }
+            else {
+                regex.append("(\\p{Nd}++)");
+            }
+            return true;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        void setCalendar(final FastDateParser parser, final Calendar cal, final String value) {
+            cal.set(field, modify(Integer.parseInt(value)));
+        }
+
+        /**
+         * Make any modifications to parsed integer
+         * @param iValue The parsed integer
+         * @return The modified value
+         */
+        int modify(final int iValue) {
+            return iValue;
+        }
+    }
+
+    private static final Strategy ABBREVIATED_YEAR_STRATEGY = new NumberStrategy(Calendar.YEAR) {
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        void setCalendar(final FastDateParser parser, final Calendar cal, final String value) {
+            int iValue= Integer.parseInt(value);
+            if(iValue<100) {
+                iValue= parser.adjustYear(iValue);
+            }
+            cal.set(Calendar.YEAR, iValue);
+        }
+    };
+
+    /**
+     * A strategy that handles a timezone field in the parsing pattern
+     */
+    private static class TimeZoneStrategy extends Strategy {
+
+        private final String validTimeZoneChars;
+        private final SortedMap<String, TimeZone> tzNames= new TreeMap<String, TimeZone>(String.CASE_INSENSITIVE_ORDER);
+
+        /**
+         * Index of zone id
+         */
+        private static final int ID = 0;
+        /**
+         * Index of the long name of zone in standard time
+         */
+        private static final int LONG_STD = 1;
+        /**
+         * Index of the short name of zone in standard time
+         */
+        private static final int SHORT_STD = 2;
+        /**
+         * Index of the long name of zone in daylight saving time
+         */
+        private static final int LONG_DST = 3;
+        /**
+         * Index of the short name of zone in daylight saving time
+         */
+        private static final int SHORT_DST = 4;
+
+        /**
+         * Construct a Strategy that parses a TimeZone
+         * @param locale The Locale
+         */
+        TimeZoneStrategy(final Locale locale) {
+            final String[][] zones = DateFormatSymbols.getInstance(locale).getZoneStrings();
+            for (final String[] zone : zones) {
+                if (zone[ID].startsWith("GMT")) {
+                    continue;
+                }
+                final TimeZone tz = TimeZone.getTimeZone(zone[ID]);
+                if (!tzNames.containsKey(zone[LONG_STD])){
+                    tzNames.put(zone[LONG_STD], tz);
+                }
+                if (!tzNames.containsKey(zone[SHORT_STD])){
+                    tzNames.put(zone[SHORT_STD], tz);
+                }
+                if (tz.useDaylightTime()) {
+                    if (!tzNames.containsKey(zone[LONG_DST])){
+                        tzNames.put(zone[LONG_DST], tz);
+                    }
+                    if (!tzNames.containsKey(zone[SHORT_DST])){
+                        tzNames.put(zone[SHORT_DST], tz);
+                    }
+                }
+            }
+
+            final StringBuilder sb= new StringBuilder();
+            sb.append("(GMT[+-]\\d{1,2}:\\d{2}").append('|');
+            sb.append("[+-]\\d{4}").append('|');
+            for(final String id : tzNames.keySet()) {
+                escapeRegex(sb, id, false).append('|');
+            }
+            sb.setCharAt(sb.length()-1, ')');
+            validTimeZoneChars= sb.toString();
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        boolean addRegex(final FastDateParser parser, final StringBuilder regex) {
+            regex.append(validTimeZoneChars);
+            return true;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        void setCalendar(final FastDateParser parser, final Calendar cal, final String value) {
+            TimeZone tz;
+            if(value.charAt(0)=='+' || value.charAt(0)=='-') {
+                tz= TimeZone.getTimeZone("GMT"+value);
+            }
+            else if(value.startsWith("GMT")) {
+                tz= TimeZone.getTimeZone(value);
+            }
+            else {
+                tz= tzNames.get(value);
+                if(tz==null) {
+                    throw new IllegalArgumentException(value + " is not a supported timezone name");
+                }
+            }
+            cal.setTimeZone(tz);
+        }
+    }
+    
+    private static class ISO8601TimeZoneStrategy extends Strategy {
+        // Z, +hh, -hh, +hhmm, -hhmm, +hh:mm or -hh:mm 
+        private final String pattern;
+
+        /**
+         * Construct a Strategy that parses a TimeZone
+         * @param pattern The Pattern
+         */
+        ISO8601TimeZoneStrategy(String pattern) {
+            this.pattern = pattern;
+        }
+        
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        boolean addRegex(FastDateParser parser, StringBuilder regex) {
+            regex.append(pattern);
+            return true;
+        }
+        
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        void setCalendar(FastDateParser parser, Calendar cal, String value) {
+            if (value.equals("Z")) {
+                cal.setTimeZone(TimeZone.getTimeZone("UTC"));
+            } else {
+                cal.setTimeZone(TimeZone.getTimeZone("GMT" + value));
+            }
+        }
+        
+        private static final Strategy ISO_8601_1_STRATEGY = new ISO8601TimeZoneStrategy("(Z|(?:[+-]\\d{2}))");
+        private static final Strategy ISO_8601_2_STRATEGY = new ISO8601TimeZoneStrategy("(Z|(?:[+-]\\d{2}\\d{2}))");
+        private static final Strategy ISO_8601_3_STRATEGY = new ISO8601TimeZoneStrategy("(Z|(?:[+-]\\d{2}(?::)\\d{2}))");
+
+        /**
+         * Factory method for ISO8601TimeZoneStrategies.
+         * 
+         * @param tokenLen a token indicating the length of the TimeZone String to be formatted.
+         * @return a ISO8601TimeZoneStrategy that can format TimeZone String of length {@code tokenLen}. If no such
+         *          strategy exists, an IllegalArgumentException will be thrown.
+         */
+        static Strategy getStrategy(int tokenLen) {
+            switch(tokenLen) {
+            case 1:
+                return ISO_8601_1_STRATEGY;
+            case 2:
+                return ISO_8601_2_STRATEGY;
+            case 3:
+                return ISO_8601_3_STRATEGY;
+            default:
+                throw new IllegalArgumentException("invalid number of X");
+            }
+        }
+    }
+
+    private static final Strategy NUMBER_MONTH_STRATEGY = new NumberStrategy(Calendar.MONTH) {
+        @Override
+        int modify(final int iValue) {
+            return iValue-1;
+        }
+    };
+    private static final Strategy LITERAL_YEAR_STRATEGY = new NumberStrategy(Calendar.YEAR);
+    private static final Strategy WEEK_OF_YEAR_STRATEGY = new NumberStrategy(Calendar.WEEK_OF_YEAR);
+    private static final Strategy WEEK_OF_MONTH_STRATEGY = new NumberStrategy(Calendar.WEEK_OF_MONTH);
+    private static final Strategy DAY_OF_YEAR_STRATEGY = new NumberStrategy(Calendar.DAY_OF_YEAR);
+    private static final Strategy DAY_OF_MONTH_STRATEGY = new NumberStrategy(Calendar.DAY_OF_MONTH);
+    private static final Strategy DAY_OF_WEEK_IN_MONTH_STRATEGY = new NumberStrategy(Calendar.DAY_OF_WEEK_IN_MONTH);
+    private static final Strategy HOUR_OF_DAY_STRATEGY = new NumberStrategy(Calendar.HOUR_OF_DAY);
+    private static final Strategy HOUR24_OF_DAY_STRATEGY = new NumberStrategy(Calendar.HOUR_OF_DAY) {
+        @Override
+        int modify(final int iValue) {
+            return iValue == 24 ? 0 : iValue;
+        }
+    };
+    private static final Strategy HOUR12_STRATEGY = new NumberStrategy(Calendar.HOUR) {
+        @Override
+        int modify(final int iValue) {
+            return iValue == 12 ? 0 : iValue;
+        }
+    };
+    private static final Strategy HOUR_STRATEGY = new NumberStrategy(Calendar.HOUR);
+    private static final Strategy MINUTE_STRATEGY = new NumberStrategy(Calendar.MINUTE);
+    private static final Strategy SECOND_STRATEGY = new NumberStrategy(Calendar.SECOND);
+    private static final Strategy MILLISECOND_STRATEGY = new NumberStrategy(Calendar.MILLISECOND);
+    private static final Strategy ISO_8601_STRATEGY = new ISO8601TimeZoneStrategy("(Z|(?:[+-]\\d{2}(?::?\\d{2})?))");
+
+
+}

--- a/src/main/java/org/sqlite/date/FastDatePrinter.java
+++ b/src/main/java/org/sqlite/date/FastDatePrinter.java
@@ -1,0 +1,1334 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sqlite.date;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.Serializable;
+import java.text.DateFormat;
+import java.text.DateFormatSymbols;
+import java.text.FieldPosition;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.List;
+import java.util.Locale;
+import java.util.TimeZone;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * <p>FastDatePrinter is a fast and thread-safe version of
+ * {@link java.text.SimpleDateFormat}.</p>
+ *
+ * <p>To obtain a FastDatePrinter, use {@link FastDateFormat#getInstance(String, TimeZone, Locale)} 
+ * or another variation of the factory methods of {@link FastDateFormat}.</p>
+ * 
+ * <p>Since FastDatePrinter is thread safe, you can use a static member instance:</p>
+ * <code>
+ *     private static final DatePrinter DATE_PRINTER = FastDateFormat.getInstance("yyyy-MM-dd");
+ * </code>
+ * 
+ * <p>This class can be used as a direct replacement to
+ * {@code SimpleDateFormat} in most formatting situations.
+ * This class is especially useful in multi-threaded server environments.
+ * {@code SimpleDateFormat} is not thread-safe in any JDK version,
+ * nor will it be as Sun have closed the bug/RFE.
+ * </p>
+ *
+ * <p>Only formatting is supported by this class, but all patterns are compatible with
+ * SimpleDateFormat (except time zones and some year patterns - see below).</p>
+ *
+ * <p>Java 1.4 introduced a new pattern letter, {@code 'Z'}, to represent
+ * time zones in RFC822 format (eg. {@code +0800} or {@code -1100}).
+ * This pattern letter can be used here (on all JDK versions).</p>
+ *
+ * <p>In addition, the pattern {@code 'ZZ'} has been made to represent
+ * ISO 8601 full format time zones (eg. {@code +08:00} or {@code -11:00}).
+ * This introduces a minor incompatibility with Java 1.4, but at a gain of
+ * useful functionality.</p>
+ * 
+ * <p>Starting with JDK7, ISO 8601 support was added using the pattern {@code 'X'}.
+ * To maintain compatibility, {@code 'ZZ'} will continue to be supported, but using
+ * one of the {@code 'X'} formats is recommended.
+ *
+ * <p>Javadoc cites for the year pattern: <i>For formatting, if the number of
+ * pattern letters is 2, the year is truncated to 2 digits; otherwise it is
+ * interpreted as a number.</i> Starting with Java 1.7 a pattern of 'Y' or
+ * 'YYY' will be formatted as '2003', while it was '03' in former Java
+ * versions. FastDatePrinter implements the behavior of Java 7.</p>
+ *
+ * @version $Id$
+ * @since 3.2
+ * @see FastDateParser
+ */
+public class FastDatePrinter implements DatePrinter, Serializable {
+    // A lot of the speed in this class comes from caching, but some comes
+    // from the special int to StringBuffer conversion.
+    //
+    // The following produces a padded 2 digit number:
+    //   buffer.append((char)(value / 10 + '0'));
+    //   buffer.append((char)(value % 10 + '0'));
+    //
+    // Note that the fastest append to StringBuffer is a single char (used here).
+    // Note that Integer.toString() is not called, the conversion is simply
+    // taking the value and adding (mathematically) the ASCII value for '0'.
+    // So, don't change this code! It works and is very fast.
+
+    /**
+     * Required for serialization support.
+     *
+     * @see java.io.Serializable
+     */
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * FULL locale dependent date or time style.
+     */
+    public static final int FULL = DateFormat.FULL;
+    /**
+     * LONG locale dependent date or time style.
+     */
+    public static final int LONG = DateFormat.LONG;
+    /**
+     * MEDIUM locale dependent date or time style.
+     */
+    public static final int MEDIUM = DateFormat.MEDIUM;
+    /**
+     * SHORT locale dependent date or time style.
+     */
+    public static final int SHORT = DateFormat.SHORT;
+
+    /**
+     * The pattern.
+     */
+    private final String mPattern;
+    /**
+     * The time zone.
+     */
+    private final TimeZone mTimeZone;
+    /**
+     * The locale.
+     */
+    private final Locale mLocale;
+    /**
+     * The parsed rules.
+     */
+    private transient Rule[] mRules;
+    /**
+     * The estimated maximum length.
+     */
+    private transient int mMaxLengthEstimate;
+
+    // Constructor
+    //-----------------------------------------------------------------------
+    /**
+     * <p>Constructs a new FastDatePrinter.</p>
+     * Use {@link FastDateFormat#getInstance(String, TimeZone, Locale)}  or another variation of the 
+     * factory methods of {@link FastDateFormat} to get a cached FastDatePrinter instance.
+     *
+     * @param pattern  {@link java.text.SimpleDateFormat} compatible pattern
+     * @param timeZone  non-null time zone to use
+     * @param locale  non-null locale to use
+     * @throws NullPointerException if pattern, timeZone, or locale is null.
+     */
+    protected FastDatePrinter(final String pattern, final TimeZone timeZone, final Locale locale) {
+        mPattern = pattern;
+        mTimeZone = timeZone;
+        mLocale = locale;
+
+        init();
+    }
+
+    /**
+     * <p>Initializes the instance for first use.</p>
+     */
+    private void init() {
+        final List<Rule> rulesList = parsePattern();
+        mRules = rulesList.toArray(new Rule[rulesList.size()]);
+
+        int len = 0;
+        for (int i=mRules.length; --i >= 0; ) {
+            len += mRules[i].estimateLength();
+        }
+
+        mMaxLengthEstimate = len;
+    }
+
+    // Parse the pattern
+    //-----------------------------------------------------------------------
+    /**
+     * <p>Returns a list of Rules given a pattern.</p>
+     *
+     * @return a {@code List} of Rule objects
+     * @throws IllegalArgumentException if pattern is invalid
+     */
+    protected List<Rule> parsePattern() {
+        final DateFormatSymbols symbols = new DateFormatSymbols(mLocale);
+        final List<Rule> rules = new ArrayList<Rule>();
+
+        final String[] ERAs = symbols.getEras();
+        final String[] months = symbols.getMonths();
+        final String[] shortMonths = symbols.getShortMonths();
+        final String[] weekdays = symbols.getWeekdays();
+        final String[] shortWeekdays = symbols.getShortWeekdays();
+        final String[] AmPmStrings = symbols.getAmPmStrings();
+
+        final int length = mPattern.length();
+        final int[] indexRef = new int[1];
+
+        for (int i = 0; i < length; i++) {
+            indexRef[0] = i;
+            final String token = parseToken(mPattern, indexRef);
+            i = indexRef[0];
+
+            final int tokenLen = token.length();
+            if (tokenLen == 0) {
+                break;
+            }
+
+            Rule rule;
+            final char c = token.charAt(0);
+
+            switch (c) {
+            case 'G': // era designator (text)
+                rule = new TextField(Calendar.ERA, ERAs);
+                break;
+            case 'y': // year (number)
+                if (tokenLen == 2) {
+                    rule = TwoDigitYearField.INSTANCE;
+                } else {
+                    rule = selectNumberRule(Calendar.YEAR, tokenLen < 4 ? 4 : tokenLen);
+                }
+                break;
+            case 'M': // month in year (text and number)
+                if (tokenLen >= 4) {
+                    rule = new TextField(Calendar.MONTH, months);
+                } else if (tokenLen == 3) {
+                    rule = new TextField(Calendar.MONTH, shortMonths);
+                } else if (tokenLen == 2) {
+                    rule = TwoDigitMonthField.INSTANCE;
+                } else {
+                    rule = UnpaddedMonthField.INSTANCE;
+                }
+                break;
+            case 'd': // day in month (number)
+                rule = selectNumberRule(Calendar.DAY_OF_MONTH, tokenLen);
+                break;
+            case 'h': // hour in am/pm (number, 1..12)
+                rule = new TwelveHourField(selectNumberRule(Calendar.HOUR, tokenLen));
+                break;
+            case 'H': // hour in day (number, 0..23)
+                rule = selectNumberRule(Calendar.HOUR_OF_DAY, tokenLen);
+                break;
+            case 'm': // minute in hour (number)
+                rule = selectNumberRule(Calendar.MINUTE, tokenLen);
+                break;
+            case 's': // second in minute (number)
+                rule = selectNumberRule(Calendar.SECOND, tokenLen);
+                break;
+            case 'S': // millisecond (number)
+                rule = selectNumberRule(Calendar.MILLISECOND, tokenLen);
+                break;
+            case 'E': // day in week (text)
+                rule = new TextField(Calendar.DAY_OF_WEEK, tokenLen < 4 ? shortWeekdays : weekdays);
+                break;
+            case 'D': // day in year (number)
+                rule = selectNumberRule(Calendar.DAY_OF_YEAR, tokenLen);
+                break;
+            case 'F': // day of week in month (number)
+                rule = selectNumberRule(Calendar.DAY_OF_WEEK_IN_MONTH, tokenLen);
+                break;
+            case 'w': // week in year (number)
+                rule = selectNumberRule(Calendar.WEEK_OF_YEAR, tokenLen);
+                break;
+            case 'W': // week in month (number)
+                rule = selectNumberRule(Calendar.WEEK_OF_MONTH, tokenLen);
+                break;
+            case 'a': // am/pm marker (text)
+                rule = new TextField(Calendar.AM_PM, AmPmStrings);
+                break;
+            case 'k': // hour in day (1..24)
+                rule = new TwentyFourHourField(selectNumberRule(Calendar.HOUR_OF_DAY, tokenLen));
+                break;
+            case 'K': // hour in am/pm (0..11)
+                rule = selectNumberRule(Calendar.HOUR, tokenLen);
+                break;
+            case 'X': // ISO 8601 
+                rule = Iso8601_Rule.getRule(tokenLen);
+                break;    
+            case 'z': // time zone (text)
+                if (tokenLen >= 4) {
+                    rule = new TimeZoneNameRule(mTimeZone, mLocale, TimeZone.LONG);
+                } else {
+                    rule = new TimeZoneNameRule(mTimeZone, mLocale, TimeZone.SHORT);
+                }
+                break;
+            case 'Z': // time zone (value)
+                if (tokenLen == 1) {
+                    rule = TimeZoneNumberRule.INSTANCE_NO_COLON;
+                } else if (tokenLen == 2) {
+                    rule = TimeZoneNumberRule.INSTANCE_ISO_8601;
+                } else {
+                    rule = TimeZoneNumberRule.INSTANCE_COLON;
+                }
+                break;
+            case '\'': // literal text
+                final String sub = token.substring(1);
+                if (sub.length() == 1) {
+                    rule = new CharacterLiteral(sub.charAt(0));
+                } else {
+                    rule = new StringLiteral(sub);
+                }
+                break;
+            default:
+                throw new IllegalArgumentException("Illegal pattern component: " + token);
+            }
+
+            rules.add(rule);
+        }
+
+        return rules;
+    }
+
+    /**
+     * <p>Performs the parsing of tokens.</p>
+     *
+     * @param pattern  the pattern
+     * @param indexRef  index references
+     * @return parsed token
+     */
+    protected String parseToken(final String pattern, final int[] indexRef) {
+        final StringBuilder buf = new StringBuilder();
+
+        int i = indexRef[0];
+        final int length = pattern.length();
+
+        char c = pattern.charAt(i);
+        if (c >= 'A' && c <= 'Z' || c >= 'a' && c <= 'z') {
+            // Scan a run of the same character, which indicates a time
+            // pattern.
+            buf.append(c);
+
+            while (i + 1 < length) {
+                final char peek = pattern.charAt(i + 1);
+                if (peek == c) {
+                    buf.append(c);
+                    i++;
+                } else {
+                    break;
+                }
+            }
+        } else {
+            // This will identify token as text.
+            buf.append('\'');
+
+            boolean inLiteral = false;
+
+            for (; i < length; i++) {
+                c = pattern.charAt(i);
+
+                if (c == '\'') {
+                    if (i + 1 < length && pattern.charAt(i + 1) == '\'') {
+                        // '' is treated as escaped '
+                        i++;
+                        buf.append(c);
+                    } else {
+                        inLiteral = !inLiteral;
+                    }
+                } else if (!inLiteral &&
+                         (c >= 'A' && c <= 'Z' || c >= 'a' && c <= 'z')) {
+                    i--;
+                    break;
+                } else {
+                    buf.append(c);
+                }
+            }
+        }
+
+        indexRef[0] = i;
+        return buf.toString();
+    }
+
+    /**
+     * <p>Gets an appropriate rule for the padding required.</p>
+     *
+     * @param field  the field to get a rule for
+     * @param padding  the padding required
+     * @return a new rule with the correct padding
+     */
+    protected NumberRule selectNumberRule(final int field, final int padding) {
+        switch (padding) {
+        case 1:
+            return new UnpaddedNumberField(field);
+        case 2:
+            return new TwoDigitNumberField(field);
+        default:
+            return new PaddedNumberField(field, padding);
+        }
+    }
+
+    // Format methods
+    //-----------------------------------------------------------------------
+    /**
+     * <p>Formats a {@code Date}, {@code Calendar} or
+     * {@code Long} (milliseconds) object.</p>
+     *
+     * @param obj  the object to format
+     * @param toAppendTo  the buffer to append to
+     * @param pos  the position - ignored
+     * @return the buffer passed in
+     */
+    public StringBuffer format(final Object obj, final StringBuffer toAppendTo, final FieldPosition pos) {
+        if (obj instanceof Date) {
+            return format((Date) obj, toAppendTo);
+        } else if (obj instanceof Calendar) {
+            return format((Calendar) obj, toAppendTo);
+        } else if (obj instanceof Long) {
+            return format(((Long) obj).longValue(), toAppendTo);
+        } else {
+            throw new IllegalArgumentException("Unknown class: " +
+                (obj == null ? "<null>" : obj.getClass().getName()));
+        }
+    }
+
+    /* (non-Javadoc)
+     * @see org.apache.commons.lang3.time.DatePrinter#format(long)
+     */
+    public String format(final long millis) {
+        final Calendar c = newCalendar();  // hard code GregorianCalendar
+        c.setTimeInMillis(millis);
+        return applyRulesToString(c);
+    }
+
+    /**
+     * Creates a String representation of the given Calendar by applying the rules of this printer to it.
+     * @param c the Calender to apply the rules to.
+     * @return a String representation of the given Calendar.
+     */
+    private String applyRulesToString(final Calendar c) {
+        return applyRules(c, new StringBuffer(mMaxLengthEstimate)).toString();
+    }
+
+    /**
+     * Creation method for ne calender instances.
+     * @return a new Calendar instance.
+     */
+    private GregorianCalendar newCalendar() {
+        // hard code GregorianCalendar
+        return new GregorianCalendar(mTimeZone, mLocale);
+    }
+
+    /* (non-Javadoc)
+     * @see org.apache.commons.lang3.time.DatePrinter#format(java.util.Date)
+     */
+    public String format(final Date date) {
+        final Calendar c = newCalendar();  // hard code GregorianCalendar
+        c.setTime(date);
+        return applyRulesToString(c);
+    }
+
+    /* (non-Javadoc)
+     * @see org.apache.commons.lang3.time.DatePrinter#format(java.util.Calendar)
+     */
+    public String format(final Calendar calendar) {
+        return format(calendar, new StringBuffer(mMaxLengthEstimate)).toString();
+    }
+
+    /* (non-Javadoc)
+     * @see org.apache.commons.lang3.time.DatePrinter#format(long, java.lang.StringBuffer)
+     */
+    public StringBuffer format(final long millis, final StringBuffer buf) {
+        return format(new Date(millis), buf);
+    }
+
+    /* (non-Javadoc)
+     * @see org.apache.commons.lang3.time.DatePrinter#format(java.util.Date, java.lang.StringBuffer)
+     */
+    public StringBuffer format(final Date date, final StringBuffer buf) {
+        final Calendar c = newCalendar();  // hard code GregorianCalendar
+        c.setTime(date);
+        return applyRules(c, buf);
+    }
+
+    /* (non-Javadoc)
+     * @see org.apache.commons.lang3.time.DatePrinter#format(java.util.Calendar, java.lang.StringBuffer)
+     */
+    public StringBuffer format(final Calendar calendar, final StringBuffer buf) {
+        return applyRules(calendar, buf);
+    }
+
+    /**
+     * <p>Performs the formatting by applying the rules to the
+     * specified calendar.</p>
+     *
+     * @param calendar  the calendar to format
+     * @param buf  the buffer to format into
+     * @return the specified string buffer
+     */
+    protected StringBuffer applyRules(final Calendar calendar, final StringBuffer buf) {
+        for (final Rule rule : mRules) {
+            rule.appendTo(buf, calendar);
+        }
+        return buf;
+    }
+
+    // Accessors
+    //-----------------------------------------------------------------------
+    /* (non-Javadoc)
+     * @see org.apache.commons.lang3.time.DatePrinter#getPattern()
+     */
+    public String getPattern() {
+        return mPattern;
+    }
+
+    /* (non-Javadoc)
+     * @see org.apache.commons.lang3.time.DatePrinter#getTimeZone()
+     */
+    public TimeZone getTimeZone() {
+        return mTimeZone;
+    }
+
+    /* (non-Javadoc)
+     * @see org.apache.commons.lang3.time.DatePrinter#getLocale()
+     */
+    public Locale getLocale() {
+        return mLocale;
+    }
+
+    /**
+     * <p>Gets an estimate for the maximum string length that the
+     * formatter will produce.</p>
+     *
+     * <p>The actual formatted length will almost always be less than or
+     * equal to this amount.</p>
+     *
+     * @return the maximum formatted length
+     */
+    public int getMaxLengthEstimate() {
+        return mMaxLengthEstimate;
+    }
+
+    // Basics
+    //-----------------------------------------------------------------------
+    /**
+     * <p>Compares two objects for equality.</p>
+     *
+     * @param obj  the object to compare to
+     * @return {@code true} if equal
+     */
+    @Override
+    public boolean equals(final Object obj) {
+        if (obj instanceof FastDatePrinter == false) {
+            return false;
+        }
+        final FastDatePrinter other = (FastDatePrinter) obj;
+        return mPattern.equals(other.mPattern)
+            && mTimeZone.equals(other.mTimeZone) 
+            && mLocale.equals(other.mLocale);
+    }
+
+    /**
+     * <p>Returns a hashcode compatible with equals.</p>
+     *
+     * @return a hashcode compatible with equals
+     */
+    @Override
+    public int hashCode() {
+        return mPattern.hashCode() + 13 * (mTimeZone.hashCode() + 13 * mLocale.hashCode());
+    }
+
+    /**
+     * <p>Gets a debugging string version of this formatter.</p>
+     *
+     * @return a debugging string
+     */
+    @Override
+    public String toString() {
+        return "FastDatePrinter[" + mPattern + "," + mLocale + "," + mTimeZone.getID() + "]";
+    }
+
+    // Serializing
+    //-----------------------------------------------------------------------
+    /**
+     * Create the object after serialization. This implementation reinitializes the
+     * transient properties.
+     *
+     * @param in ObjectInputStream from which the object is being deserialized.
+     * @throws IOException if there is an IO issue.
+     * @throws ClassNotFoundException if a class cannot be found.
+     */
+    private void readObject(final ObjectInputStream in) throws IOException, ClassNotFoundException {
+        in.defaultReadObject();
+        init();
+    }
+
+    /**
+     * Appends digits to the given buffer.
+     * 
+     * @param buffer the buffer to append to.
+     * @param value the value to append digits from.
+     */
+    private static void appendDigits(final StringBuffer buffer, final int value) {
+        buffer.append((char)(value / 10 + '0'));
+        buffer.append((char)(value % 10 + '0'));
+    }
+
+    // Rules
+    //-----------------------------------------------------------------------
+    /**
+     * <p>Inner class defining a rule.</p>
+     */
+    private interface Rule {
+        /**
+         * Returns the estimated length of the result.
+         *
+         * @return the estimated length
+         */
+        int estimateLength();
+
+        /**
+         * Appends the value of the specified calendar to the output buffer based on the rule implementation.
+         *
+         * @param buffer the output buffer
+         * @param calendar calendar to be appended
+         */
+        void appendTo(StringBuffer buffer, Calendar calendar);
+    }
+
+    /**
+     * <p>Inner class defining a numeric rule.</p>
+     */
+    private interface NumberRule extends Rule {
+        /**
+         * Appends the specified value to the output buffer based on the rule implementation.
+         *
+         * @param buffer the output buffer
+         * @param value the value to be appended
+         */
+        void appendTo(StringBuffer buffer, int value);
+    }
+
+    /**
+     * <p>Inner class to output a constant single character.</p>
+     */
+    private static class CharacterLiteral implements Rule {
+        private final char mValue;
+
+        /**
+         * Constructs a new instance of {@code CharacterLiteral}
+         * to hold the specified value.
+         *
+         * @param value the character literal
+         */
+        CharacterLiteral(final char value) {
+            mValue = value;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        public int estimateLength() {
+            return 1;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        public void appendTo(final StringBuffer buffer, final Calendar calendar) {
+            buffer.append(mValue);
+        }
+    }
+
+    /**
+     * <p>Inner class to output a constant string.</p>
+     */
+    private static class StringLiteral implements Rule {
+        private final String mValue;
+
+        /**
+         * Constructs a new instance of {@code StringLiteral}
+         * to hold the specified value.
+         *
+         * @param value the string literal
+         */
+        StringLiteral(final String value) {
+            mValue = value;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        public int estimateLength() {
+            return mValue.length();
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        public void appendTo(final StringBuffer buffer, final Calendar calendar) {
+            buffer.append(mValue);
+        }
+    }
+
+    /**
+     * <p>Inner class to output one of a set of values.</p>
+     */
+    private static class TextField implements Rule {
+        private final int mField;
+        private final String[] mValues;
+
+        /**
+         * Constructs an instance of {@code TextField}
+         * with the specified field and values.
+         *
+         * @param field the field
+         * @param values the field values
+         */
+        TextField(final int field, final String[] values) {
+            mField = field;
+            mValues = values;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        public int estimateLength() {
+            int max = 0;
+            for (int i=mValues.length; --i >= 0; ) {
+                final int len = mValues[i].length();
+                if (len > max) {
+                    max = len;
+                }
+            }
+            return max;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        public void appendTo(final StringBuffer buffer, final Calendar calendar) {
+            buffer.append(mValues[calendar.get(mField)]);
+        }
+    }
+
+    /**
+     * <p>Inner class to output an unpadded number.</p>
+     */
+    private static class UnpaddedNumberField implements NumberRule {
+        private final int mField;
+
+        /**
+         * Constructs an instance of {@code UnpadedNumberField} with the specified field.
+         *
+         * @param field the field
+         */
+        UnpaddedNumberField(final int field) {
+            mField = field;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        public int estimateLength() {
+            return 4;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        public void appendTo(final StringBuffer buffer, final Calendar calendar) {
+            appendTo(buffer, calendar.get(mField));
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        public final void appendTo(final StringBuffer buffer, final int value) {
+            if (value < 10) {
+                buffer.append((char)(value + '0'));
+            } else if (value < 100) {
+                appendDigits(buffer, value);
+            } else {
+                buffer.append(value);
+            }
+        }
+    }
+
+    /**
+     * <p>Inner class to output an unpadded month.</p>
+     */
+    private static class UnpaddedMonthField implements NumberRule {
+        static final UnpaddedMonthField INSTANCE = new UnpaddedMonthField();
+
+        /**
+         * Constructs an instance of {@code UnpaddedMonthField}.
+         *
+         */
+        UnpaddedMonthField() {
+            super();
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        public int estimateLength() {
+            return 2;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        public void appendTo(final StringBuffer buffer, final Calendar calendar) {
+            appendTo(buffer, calendar.get(Calendar.MONTH) + 1);
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        public final void appendTo(final StringBuffer buffer, final int value) {
+            if (value < 10) {
+                buffer.append((char)(value + '0'));
+            } else {
+                appendDigits(buffer, value);
+            }
+        }
+    }
+
+    /**
+     * <p>Inner class to output a padded number.</p>
+     */
+    private static class PaddedNumberField implements NumberRule {
+        private final int mField;
+        private final int mSize;
+
+        /**
+         * Constructs an instance of {@code PaddedNumberField}.
+         *
+         * @param field the field
+         * @param size size of the output field
+         */
+        PaddedNumberField(final int field, final int size) {
+            if (size < 3) {
+                // Should use UnpaddedNumberField or TwoDigitNumberField.
+                throw new IllegalArgumentException();
+            }
+            mField = field;
+            mSize = size;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        public int estimateLength() {
+            return mSize;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        public void appendTo(final StringBuffer buffer, final Calendar calendar) {
+            appendTo(buffer, calendar.get(mField));
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        public final void appendTo(final StringBuffer buffer, int value) {
+            // pad the buffer with adequate zeros
+            for(int digit = 0; digit<mSize; ++digit) {
+                buffer.append('0');                
+            }
+            // backfill the buffer with non-zero digits
+            int index = buffer.length();
+            for( ; value>0; value /= 10) {
+                buffer.setCharAt(--index, (char)('0' + value % 10));
+            }
+        }
+    }
+
+    /**
+     * <p>Inner class to output a two digit number.</p>
+     */
+    private static class TwoDigitNumberField implements NumberRule {
+        private final int mField;
+
+        /**
+         * Constructs an instance of {@code TwoDigitNumberField} with the specified field.
+         *
+         * @param field the field
+         */
+        TwoDigitNumberField(final int field) {
+            mField = field;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        public int estimateLength() {
+            return 2;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        public void appendTo(final StringBuffer buffer, final Calendar calendar) {
+            appendTo(buffer, calendar.get(mField));
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        public final void appendTo(final StringBuffer buffer, final int value) {
+            if (value < 100) {
+                appendDigits(buffer, value);
+            } else {
+                buffer.append(value);
+            }
+        }
+    }
+
+    /**
+     * <p>Inner class to output a two digit year.</p>
+     */
+    private static class TwoDigitYearField implements NumberRule {
+        static final TwoDigitYearField INSTANCE = new TwoDigitYearField();
+
+        /**
+         * Constructs an instance of {@code TwoDigitYearField}.
+         */
+        TwoDigitYearField() {
+            super();
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        public int estimateLength() {
+            return 2;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        public void appendTo(final StringBuffer buffer, final Calendar calendar) {
+            appendTo(buffer, calendar.get(Calendar.YEAR) % 100);
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        public final void appendTo(final StringBuffer buffer, final int value) {
+            appendDigits(buffer, value);
+        }
+    }
+
+    /**
+     * <p>Inner class to output a two digit month.</p>
+     */
+    private static class TwoDigitMonthField implements NumberRule {
+        static final TwoDigitMonthField INSTANCE = new TwoDigitMonthField();
+
+        /**
+         * Constructs an instance of {@code TwoDigitMonthField}.
+         */
+        TwoDigitMonthField() {
+            super();
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        public int estimateLength() {
+            return 2;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        public void appendTo(final StringBuffer buffer, final Calendar calendar) {
+            appendTo(buffer, calendar.get(Calendar.MONTH) + 1);
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        public final void appendTo(final StringBuffer buffer, final int value) {
+            appendDigits(buffer, value);
+        }
+    }
+
+    /**
+     * <p>Inner class to output the twelve hour field.</p>
+     */
+    private static class TwelveHourField implements NumberRule {
+        private final NumberRule mRule;
+
+        /**
+         * Constructs an instance of {@code TwelveHourField} with the specified
+         * {@code NumberRule}.
+         *
+         * @param rule the rule
+         */
+        TwelveHourField(final NumberRule rule) {
+            mRule = rule;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        public int estimateLength() {
+            return mRule.estimateLength();
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        public void appendTo(final StringBuffer buffer, final Calendar calendar) {
+            int value = calendar.get(Calendar.HOUR);
+            if (value == 0) {
+                value = calendar.getLeastMaximum(Calendar.HOUR) + 1;
+            }
+            mRule.appendTo(buffer, value);
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        public void appendTo(final StringBuffer buffer, final int value) {
+            mRule.appendTo(buffer, value);
+        }
+    }
+
+    /**
+     * <p>Inner class to output the twenty four hour field.</p>
+     */
+    private static class TwentyFourHourField implements NumberRule {
+        private final NumberRule mRule;
+
+        /**
+         * Constructs an instance of {@code TwentyFourHourField} with the specified
+         * {@code NumberRule}.
+         *
+         * @param rule the rule
+         */
+        TwentyFourHourField(final NumberRule rule) {
+            mRule = rule;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        public int estimateLength() {
+            return mRule.estimateLength();
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        public void appendTo(final StringBuffer buffer, final Calendar calendar) {
+            int value = calendar.get(Calendar.HOUR_OF_DAY);
+            if (value == 0) {
+                value = calendar.getMaximum(Calendar.HOUR_OF_DAY) + 1;
+            }
+            mRule.appendTo(buffer, value);
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        public void appendTo(final StringBuffer buffer, final int value) {
+            mRule.appendTo(buffer, value);
+        }
+    }
+
+    //-----------------------------------------------------------------------
+
+    private static final ConcurrentMap<TimeZoneDisplayKey, String> cTimeZoneDisplayCache =
+        new ConcurrentHashMap<TimeZoneDisplayKey, String>(7);
+    /**
+     * <p>Gets the time zone display name, using a cache for performance.</p>
+     *
+     * @param tz  the zone to query
+     * @param daylight  true if daylight savings
+     * @param style  the style to use {@code TimeZone.LONG} or {@code TimeZone.SHORT}
+     * @param locale  the locale to use
+     * @return the textual name of the time zone
+     */
+    static String getTimeZoneDisplay(final TimeZone tz, final boolean daylight, final int style, final Locale locale) {
+        final TimeZoneDisplayKey key = new TimeZoneDisplayKey(tz, daylight, style, locale);
+        String value = cTimeZoneDisplayCache.get(key);
+        if (value == null) {
+            // This is a very slow call, so cache the results.
+            value = tz.getDisplayName(daylight, style, locale);
+            final String prior = cTimeZoneDisplayCache.putIfAbsent(key, value);
+            if (prior != null) {
+                value= prior;
+            }
+        }
+        return value;
+    }
+
+    /**
+     * <p>Inner class to output a time zone name.</p>
+     */
+    private static class TimeZoneNameRule implements Rule {
+        private final Locale mLocale;
+        private final int mStyle;
+        private final String mStandard;
+        private final String mDaylight;
+
+        /**
+         * Constructs an instance of {@code TimeZoneNameRule} with the specified properties.
+         *
+         * @param timeZone the time zone
+         * @param locale the locale
+         * @param style the style
+         */
+        TimeZoneNameRule(final TimeZone timeZone, final Locale locale, final int style) {
+            mLocale = locale;
+            mStyle = style;
+            
+            mStandard = getTimeZoneDisplay(timeZone, false, style, locale);
+            mDaylight = getTimeZoneDisplay(timeZone, true, style, locale);
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        public int estimateLength() {
+            // We have no access to the Calendar object that will be passed to
+            // appendTo so base estimate on the TimeZone passed to the
+            // constructor
+            return Math.max(mStandard.length(), mDaylight.length());
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        public void appendTo(final StringBuffer buffer, final Calendar calendar) {
+            final TimeZone zone = calendar.getTimeZone();
+            if (calendar.get(Calendar.DST_OFFSET) != 0) {
+                buffer.append(getTimeZoneDisplay(zone, true, mStyle, mLocale));
+            } else {
+                buffer.append(getTimeZoneDisplay(zone, false, mStyle, mLocale));
+            }
+        }
+    }
+
+    /**
+     * <p>Inner class to output a time zone as a number {@code +/-HHMM}
+     * or {@code +/-HH:MM}.</p>
+     */
+    private static class TimeZoneNumberRule implements Rule {
+        static final TimeZoneNumberRule INSTANCE_COLON = new TimeZoneNumberRule(true, false);
+        static final TimeZoneNumberRule INSTANCE_NO_COLON = new TimeZoneNumberRule(false, false);
+        static final TimeZoneNumberRule INSTANCE_ISO_8601 = new TimeZoneNumberRule(true, true);
+        
+        final boolean mColon;
+        final boolean mISO8601;
+
+        /**
+         * Constructs an instance of {@code TimeZoneNumberRule} with the specified properties.
+         *
+         * @param colon add colon between HH and MM in the output if {@code true}
+         * @param iso8601 create an ISO 8601 format output
+         */
+        TimeZoneNumberRule(final boolean colon, final boolean iso8601) {
+            mColon = colon;
+            mISO8601 = iso8601;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        public int estimateLength() {
+            return 5;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        public void appendTo(final StringBuffer buffer, final Calendar calendar) {
+            if (mISO8601 && calendar.getTimeZone().getID().equals("UTC")) {
+                buffer.append("Z");
+                return;
+            }
+            
+            int offset = calendar.get(Calendar.ZONE_OFFSET) + calendar.get(Calendar.DST_OFFSET);
+
+            if (offset < 0) {
+                buffer.append('-');
+                offset = -offset;
+            } else {
+                buffer.append('+');
+            }
+
+            final int hours = offset / (60 * 60 * 1000);
+            appendDigits(buffer, hours);
+
+            if (mColon) {
+                buffer.append(':');
+            }
+
+            final int minutes = offset / (60 * 1000) - 60 * hours;
+            appendDigits(buffer, minutes);
+        }
+    }
+
+    /**
+     * <p>Inner class to output a time zone as a number {@code +/-HHMM}
+     * or {@code +/-HH:MM}.</p>
+     */
+    private static class Iso8601_Rule implements Rule {
+        
+        // Sign TwoDigitHours or Z
+        static final Iso8601_Rule ISO8601_HOURS = new Iso8601_Rule(3);       
+        // Sign TwoDigitHours Minutes or Z
+        static final Iso8601_Rule ISO8601_HOURS_MINUTES = new Iso8601_Rule(5);
+        // Sign TwoDigitHours : Minutes or Z
+        static final Iso8601_Rule ISO8601_HOURS_COLON_MINUTES = new Iso8601_Rule(6);
+
+        /**
+         * Factory method for Iso8601_Rules.
+         *
+         * @param tokenLen a token indicating the length of the TimeZone String to be formatted.
+         * @return a Iso8601_Rule that can format TimeZone String of length {@code tokenLen}. If no such
+         *          rule exists, an IllegalArgumentException will be thrown.
+         */
+        static Iso8601_Rule getRule(int tokenLen) {
+            switch(tokenLen) {
+            case 1:
+                return Iso8601_Rule.ISO8601_HOURS;
+            case 2:
+                return Iso8601_Rule.ISO8601_HOURS_MINUTES;
+            case 3:
+                return Iso8601_Rule.ISO8601_HOURS_COLON_MINUTES;
+            default:
+                throw new IllegalArgumentException("invalid number of X");                    
+            }
+        }        
+        
+        final int length;
+
+        /**
+         * Constructs an instance of {@code Iso8601_Rule} with the specified properties.
+         *
+         * @param length The number of characters in output (unless Z is output)
+         */
+        Iso8601_Rule(final int length) {
+            this.length = length;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        public int estimateLength() {
+            return length;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        public void appendTo(final StringBuffer buffer, final Calendar calendar) {
+            int zoneOffset = calendar.get(Calendar.ZONE_OFFSET);
+            if (zoneOffset == 0) {
+                buffer.append("Z");
+                return;
+            }
+            
+            int offset = zoneOffset + calendar.get(Calendar.DST_OFFSET);
+
+            if (offset < 0) {
+                buffer.append('-');
+                offset = -offset;
+            } else {
+                buffer.append('+');
+            }
+
+            final int hours = offset / (60 * 60 * 1000);
+            appendDigits(buffer, hours);
+
+            if (length<5) {
+                return;
+            }
+            
+            if (length==6) {
+                buffer.append(':');
+            }
+
+            final int minutes = offset / (60 * 1000) - 60 * hours;
+            appendDigits(buffer, minutes);
+        }
+    }
+
+    // ----------------------------------------------------------------------
+    /**
+     * <p>Inner class that acts as a compound key for time zone names.</p>
+     */
+    private static class TimeZoneDisplayKey {
+        private final TimeZone mTimeZone;
+        private final int mStyle;
+        private final Locale mLocale;
+
+        /**
+         * Constructs an instance of {@code TimeZoneDisplayKey} with the specified properties.
+         *
+         * @param timeZone the time zone
+         * @param daylight adjust the style for daylight saving time if {@code true}
+         * @param style the timezone style
+         * @param locale the timezone locale
+         */
+        TimeZoneDisplayKey(final TimeZone timeZone,
+                           final boolean daylight, final int style, final Locale locale) {
+            mTimeZone = timeZone;
+            if (daylight) {
+                mStyle = style | 0x80000000;
+            } else {
+                mStyle = style;
+            }
+            mLocale = locale;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public int hashCode() {
+            return (mStyle * 31 + mLocale.hashCode() ) * 31 + mTimeZone.hashCode();
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public boolean equals(final Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj instanceof TimeZoneDisplayKey) {
+                final TimeZoneDisplayKey other = (TimeZoneDisplayKey)obj;
+                return
+                    mTimeZone.equals(other.mTimeZone) &&
+                    mStyle == other.mStyle &&
+                    mLocale.equals(other.mLocale);
+            }
+            return false;
+        }
+    }
+}

--- a/src/main/java/org/sqlite/date/FormatCache.java
+++ b/src/main/java/org/sqlite/date/FormatCache.java
@@ -1,0 +1,266 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sqlite.date;
+
+import java.text.DateFormat;
+import java.text.Format;
+import java.text.SimpleDateFormat;
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.TimeZone;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * <p>FormatCache is a cache and factory for {@link Format}s.</p>
+ * 
+ * @since 3.0
+ * @version $Id: FormatCache 892161 2009-12-18 07:21:10Z  $
+ */
+// TODO: Before making public move from getDateTimeInstance(Integer,...) to int; or some other approach.
+abstract class FormatCache<F extends Format> {
+    /**
+     * No date or no time.  Used in same parameters as DateFormat.SHORT or DateFormat.LONG
+     */
+    static final int NONE= -1;
+    
+    private final ConcurrentMap<MultipartKey, F> cInstanceCache 
+        = new ConcurrentHashMap<MultipartKey, F>(7);
+    
+    private static final ConcurrentMap<MultipartKey, String> cDateTimeInstanceCache 
+        = new ConcurrentHashMap<MultipartKey, String>(7);
+
+    /**
+     * <p>Gets a formatter instance using the default pattern in the
+     * default timezone and locale.</p>
+     * 
+     * @return a date/time formatter
+     */
+    public F getInstance() {
+        return getDateTimeInstance(DateFormat.SHORT, DateFormat.SHORT, TimeZone.getDefault(), Locale.getDefault());
+    }
+
+    /**
+     * <p>Gets a formatter instance using the specified pattern, time zone
+     * and locale.</p>
+     * 
+     * @param pattern  {@link java.text.SimpleDateFormat} compatible
+     *  pattern, non-null
+     * @param timeZone  the time zone, null means use the default TimeZone
+     * @param locale  the locale, null means use the default Locale
+     * @return a pattern based date/time formatter
+     * @throws IllegalArgumentException if pattern is invalid
+     *  or <code>null</code>
+     */
+    public F getInstance(final String pattern, TimeZone timeZone, Locale locale) {
+        if (pattern == null) {
+            throw new NullPointerException("pattern must not be null");
+        }
+        if (timeZone == null) {
+            timeZone = TimeZone.getDefault();
+        }
+        if (locale == null) {
+            locale = Locale.getDefault();
+        }
+        final MultipartKey key = new MultipartKey(pattern, timeZone, locale);
+        F format = cInstanceCache.get(key);
+        if (format == null) {           
+            format = createInstance(pattern, timeZone, locale);
+            final F previousValue= cInstanceCache.putIfAbsent(key, format);
+            if (previousValue != null) {
+                // another thread snuck in and did the same work
+                // we should return the instance that is in ConcurrentMap
+                format= previousValue;              
+            }
+        }
+        return format;
+    }
+    
+    /**
+     * <p>Create a format instance using the specified pattern, time zone
+     * and locale.</p>
+     * 
+     * @param pattern  {@link java.text.SimpleDateFormat} compatible pattern, this will not be null.
+     * @param timeZone  time zone, this will not be null.
+     * @param locale  locale, this will not be null.
+     * @return a pattern based date/time formatter
+     * @throws IllegalArgumentException if pattern is invalid
+     *  or <code>null</code>
+     */
+    abstract protected F createInstance(String pattern, TimeZone timeZone, Locale locale);
+        
+    /**
+     * <p>Gets a date/time formatter instance using the specified style,
+     * time zone and locale.</p>
+     * 
+     * @param dateStyle  date style: FULL, LONG, MEDIUM, or SHORT, null indicates no date in format
+     * @param timeStyle  time style: FULL, LONG, MEDIUM, or SHORT, null indicates no time in format
+     * @param timeZone  optional time zone, overrides time zone of
+     *  formatted date, null means use default Locale
+     * @param locale  optional locale, overrides system locale
+     * @return a localized standard date/time formatter
+     * @throws IllegalArgumentException if the Locale has no date/time
+     *  pattern defined
+     */
+    // This must remain private, see LANG-884 
+    private F getDateTimeInstance(final Integer dateStyle, final Integer timeStyle, final TimeZone timeZone, Locale locale) {
+        if (locale == null) {
+            locale = Locale.getDefault();
+        }
+        final String pattern = getPatternForStyle(dateStyle, timeStyle, locale);
+        return getInstance(pattern, timeZone, locale);
+    }
+
+    /**
+     * <p>Gets a date/time formatter instance using the specified style,
+     * time zone and locale.</p>
+     * 
+     * @param dateStyle  date style: FULL, LONG, MEDIUM, or SHORT
+     * @param timeStyle  time style: FULL, LONG, MEDIUM, or SHORT
+     * @param timeZone  optional time zone, overrides time zone of
+     *  formatted date, null means use default Locale
+     * @param locale  optional locale, overrides system locale
+     * @return a localized standard date/time formatter
+     * @throws IllegalArgumentException if the Locale has no date/time
+     *  pattern defined
+     */
+    // package protected, for access from FastDateFormat; do not make public or protected
+    F getDateTimeInstance(final int dateStyle, final int timeStyle, final TimeZone timeZone, final Locale locale) {
+        return getDateTimeInstance(Integer.valueOf(dateStyle), Integer.valueOf(timeStyle), timeZone, locale);
+    }
+
+    /**
+     * <p>Gets a date formatter instance using the specified style,
+     * time zone and locale.</p>
+     * 
+     * @param dateStyle  date style: FULL, LONG, MEDIUM, or SHORT
+     * @param timeZone  optional time zone, overrides time zone of
+     *  formatted date, null means use default Locale
+     * @param locale  optional locale, overrides system locale
+     * @return a localized standard date/time formatter
+     * @throws IllegalArgumentException if the Locale has no date/time
+     *  pattern defined
+     */
+    // package protected, for access from FastDateFormat; do not make public or protected
+    F getDateInstance(final int dateStyle, final TimeZone timeZone, final Locale locale) {
+        return getDateTimeInstance(Integer.valueOf(dateStyle), null, timeZone, locale);
+    }
+
+    /**
+     * <p>Gets a time formatter instance using the specified style,
+     * time zone and locale.</p>
+     * 
+     * @param timeStyle  time style: FULL, LONG, MEDIUM, or SHORT
+     * @param timeZone  optional time zone, overrides time zone of
+     *  formatted date, null means use default Locale
+     * @param locale  optional locale, overrides system locale
+     * @return a localized standard date/time formatter
+     * @throws IllegalArgumentException if the Locale has no date/time
+     *  pattern defined
+     */
+    // package protected, for access from FastDateFormat; do not make public or protected
+    F getTimeInstance(final int timeStyle, final TimeZone timeZone, final Locale locale) {
+        return getDateTimeInstance(null, Integer.valueOf(timeStyle), timeZone, locale);
+    }
+
+    /**
+     * <p>Gets a date/time format for the specified styles and locale.</p>
+     * 
+     * @param dateStyle  date style: FULL, LONG, MEDIUM, or SHORT, null indicates no date in format
+     * @param timeStyle  time style: FULL, LONG, MEDIUM, or SHORT, null indicates no time in format
+     * @param locale  The non-null locale of the desired format
+     * @return a localized standard date/time format
+     * @throws IllegalArgumentException if the Locale has no date/time pattern defined
+     */
+    // package protected, for access from test code; do not make public or protected
+    static String getPatternForStyle(final Integer dateStyle, final Integer timeStyle, final Locale locale) {
+        final MultipartKey key = new MultipartKey(dateStyle, timeStyle, locale);
+
+        String pattern = cDateTimeInstanceCache.get(key);
+        if (pattern == null) {
+            try {
+                DateFormat formatter;
+                if (dateStyle == null) {
+                    formatter = DateFormat.getTimeInstance(timeStyle.intValue(), locale);                    
+                }
+                else if (timeStyle == null) {
+                    formatter = DateFormat.getDateInstance(dateStyle.intValue(), locale);                    
+                }
+                else {
+                    formatter = DateFormat.getDateTimeInstance(dateStyle.intValue(), timeStyle.intValue(), locale);
+                }
+                pattern = ((SimpleDateFormat)formatter).toPattern();
+                final String previous = cDateTimeInstanceCache.putIfAbsent(key, pattern);
+                if (previous != null) {
+                    // even though it doesn't matter if another thread put the pattern
+                    // it's still good practice to return the String instance that is
+                    // actually in the ConcurrentMap
+                    pattern= previous;
+                }
+            } catch (final ClassCastException ex) {
+                throw new IllegalArgumentException("No date time pattern for locale: " + locale);
+            }
+        }
+        return pattern;
+    }
+
+    // ----------------------------------------------------------------------
+    /**
+     * <p>Helper class to hold multi-part Map keys</p>
+     */
+    private static class MultipartKey {
+        private final Object[] keys;
+        private int hashCode;
+
+        /**
+         * Constructs an instance of <code>MultipartKey</code> to hold the specified objects.
+         * @param keys the set of objects that make up the key.  Each key may be null.
+         */
+        public MultipartKey(final Object... keys) {
+            this.keys = keys;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public boolean equals(final Object obj) {
+            // Eliminate the usual boilerplate because
+            // this inner static class is only used in a generic ConcurrentHashMap
+            // which will not compare against other Object types
+            return Arrays.equals(keys, ((MultipartKey)obj).keys);
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public int hashCode() {
+            if(hashCode==0) {
+                int rc= 0;
+                for(final Object key : keys) {
+                    if(key!=null) {
+                        rc= rc*7 + key.hashCode();
+                    }
+                }
+                hashCode= rc;
+            }
+            return hashCode;
+        }
+    }
+
+}

--- a/src/main/java/org/sqlite/date/package-info.java
+++ b/src/main/java/org/sqlite/date/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * <p>Provides classes and methods to work with dates and durations.
+ * These classes are immutable (and therefore thread-safe) apart from {@link org.apache.commons.lang3.time.StopWatch}.</p>
+ *
+ * <p>The time package contains some basic utilities for manipulating time (a delorean, police box and grandfather clock?).
+ * These include a {@link org.apache.commons.lang3.time.StopWatch} for simple performance measurements and an optimised {@link org.sqlite.date.FastDateFormat} class.</p>
+ *
+ * <p>New in Lang 2.1 is the {@link org.apache.commons.lang3.time.DurationFormatUtils} class, which provides various methods for formatting durations.</p>
+ *
+ * @since 2.0
+ */
+package org.sqlite.date;

--- a/src/main/java/org/sqlite/jdbc3/JDBC3ResultSet.java
+++ b/src/main/java/org/sqlite/jdbc3/JDBC3ResultSet.java
@@ -14,12 +14,13 @@ import java.sql.Statement;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.sql.Types;
-import java.text.DateFormat;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import org.sqlite.date.FastDateFormat;
 
 import org.sqlite.core.CoreResultSet;
 import org.sqlite.core.CoreStatement;
@@ -323,8 +324,7 @@ public abstract class JDBC3ResultSet extends CoreResultSet {
     
             case SQLITE_TEXT:
                 try {
-                    DateFormat dateFormat = (DateFormat) stmt.conn.dateFormat.clone();
-                    dateFormat.setCalendar(cal);
+                	FastDateFormat dateFormat = FastDateFormat.getInstance(stmt.conn.dateStringFormat, cal.getTimeZone());
 
                     return new java.sql.Date(dateFormat.parse(db.column_text(stmt.pointer, markCol(col))).getTime());
                 }
@@ -487,8 +487,7 @@ public abstract class JDBC3ResultSet extends CoreResultSet {
 
             case SQLITE_TEXT:
                 try {
-                    DateFormat dateFormat = (DateFormat) stmt.conn.dateFormat.clone();
-                    dateFormat.setCalendar(cal);
+                	FastDateFormat dateFormat = FastDateFormat.getInstance(stmt.conn.dateStringFormat, cal.getTimeZone());
 
                     return new Time(dateFormat.parse(db.column_text(stmt.pointer, markCol(col))).getTime());
                 }
@@ -563,8 +562,7 @@ public abstract class JDBC3ResultSet extends CoreResultSet {
     
             case SQLITE_TEXT:
                 try {
-                    DateFormat dateFormat = (DateFormat)stmt.conn.dateFormat.clone();
-                    dateFormat.setCalendar(cal);
+                	FastDateFormat dateFormat = FastDateFormat.getInstance(stmt.conn.dateStringFormat, cal.getTimeZone());
 
                     return new Timestamp(dateFormat.parse(db.column_text(stmt.pointer, markCol(col))).getTime());
                 }

--- a/src/test/java/org/sqlite/QueryTest.java
+++ b/src/test/java/org/sqlite/QueryTest.java
@@ -17,8 +17,9 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.text.SimpleDateFormat;
 import java.util.Date;
+
+import org.sqlite.date.FastDateFormat;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -75,7 +76,7 @@ public class QueryTest
         conn.createStatement().execute("create table sample (start_time datetime)");
 
         Date now = new Date();
-        String date = new SimpleDateFormat(SQLiteConfig.DEFAULT_DATE_STRING_FORMAT).format(now);
+        String date = FastDateFormat.getInstance(SQLiteConfig.DEFAULT_DATE_STRING_FORMAT).format(now);
 
         conn.createStatement().execute("insert into sample values(" + now.getTime() + ")");
         conn.createStatement().execute("insert into sample values('" + date + "')");


### PR DESCRIPTION
SimpleDateFormat's .parse() method does not treat format Strings the same as its .format() method does.  This is a problem when dealing with dates created by ActiveRecord, which stores dates as strings with pseudo-microsecond precision in the following format: `yyyy-MM-dd HH:mm:ss.SSS000` (It's actually stored with millisecond precision, but `000` is always appended to the string.

SimpleDateFormat will properly format a date given this format string, but it fails when trying to parse a date.

The FastDateFormat utility provided by Apache Commons Lang 3.x does not have this issue.  As an added bonus, it is also faster and thread-safe.

This pull request uses FastDateFormat instead of SimpleDateFormat to get around this issue.

Unfortunately, it also has a few drawbacks.
1) make is broken because it can't find the commons-lang3-3.4.jar file.   This should be a simple fix, but I'm not familiar with make, so I'm not exactly sure where it's failing.
2) It requires the user to include commons-lang3-3.4.jar with alongside sqlite-jdbc.jar in order to work.  This may be a dealbreaker.  I'm not sure if there is a way to include the contents of the jar inside of the sqlite jar when it's built, though.  It seemed like it may be possible with Maven, but I'm not familiar with it, either.