### PR TITLE
Add a cache for ResultSet#findColumn

### DIFF
--- a/src/main/java/org/sqlite/core/CoreResultSet.java
+++ b/src/main/java/org/sqlite/core/CoreResultSet.java
@@ -17,6 +17,8 @@ package org.sqlite.core;
 
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Implements a JDBC ResultSet.
@@ -37,6 +39,7 @@ public abstract class CoreResultSet implements Codes
     protected int        lastCol;         // last column accessed, for wasNull(). -1 if none
 
     public boolean closeStmt;
+    protected Map<String, Integer> columnNameToIndex = null;
 
     /**
      * Default constructor for a given statement.
@@ -114,6 +117,7 @@ public abstract class CoreResultSet implements Codes
         limitRows = 0;
         row = 0;
         lastCol = -1;
+        columnNameToIndex = null;
 
         if (stmt == null) {
             return;
@@ -127,5 +131,20 @@ public abstract class CoreResultSet implements Codes
                 ((Statement)stmt).close();
             }
         }
+    }
+
+    protected Integer findColumnIndexInCache(String col) {
+        if (columnNameToIndex == null) {
+            return null;
+        }
+        return columnNameToIndex.get(col);
+    }
+
+    protected int addColumnIndexInCache(String col, int index) {
+        if (columnNameToIndex == null) {
+            columnNameToIndex = new HashMap<String, Integer>(cols.length);
+        }
+        columnNameToIndex.put(col, index);
+        return index;
     }
 }

--- a/src/main/java/org/sqlite/jdbc3/JDBC3ResultSet.java
+++ b/src/main/java/org/sqlite/jdbc3/JDBC3ResultSet.java
@@ -19,11 +19,9 @@ import java.util.GregorianCalendar;
 import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import org.sqlite.date.FastDateFormat;
-
 import org.sqlite.core.CoreResultSet;
 import org.sqlite.core.CoreStatement;
+import org.sqlite.date.FastDateFormat;
 
 public abstract class JDBC3ResultSet extends CoreResultSet {
     // ResultSet Functions //////////////////////////////////////////
@@ -38,25 +36,16 @@ public abstract class JDBC3ResultSet extends CoreResultSet {
      */
     public int findColumn(String col) throws SQLException {
         checkOpen();
-        int c = -1;
-        for (int i = 0; i < cols.length; i++) {
-            if (col.equalsIgnoreCase(cols[i])
-                    || (cols[i].toUpperCase().endsWith(col.toUpperCase()) && cols[i].charAt(cols[i].length()
-                            - col.length()) == '.')) {
-                if (c == -1) {
-                    c = i;
-                }
-                else {
-                    throw new SQLException("ambiguous column: '" + col + "'");
-                }
+        Integer index = findColumnIndexInCache(col);
+        if (index != null) {
+            return index;
+        }
+        for (int i=0; i < cols.length; i++) {
+            if (col.equalsIgnoreCase(cols[i])) {
+                return addColumnIndexInCache(col, i+1);
             }
         }
-        if (c == -1) {
-            throw new SQLException("no such column: '" + col + "'");
-        }
-        else {
-            return c + 1;
-        }
+        throw new SQLException("no such column: '"+col+"'");
     }
 
     /**

--- a/src/test/java/org/sqlite/ResultSetTest.java
+++ b/src/test/java/org/sqlite/ResultSetTest.java
@@ -1,0 +1,143 @@
+package org.sqlite;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ResultSetTest {
+
+    private Connection conn;
+    private Statement stat;
+
+    @Before
+    public void connect() throws Exception {
+        conn = DriverManager.getConnection("jdbc:sqlite:");
+        stat = conn.createStatement();
+        stat.executeUpdate("create table test (id int primary key, DESCRIPTION varchar(40), fOo varchar(3));");
+        stat.executeUpdate("insert into test values (1, 'description', 'bar')");
+    }
+
+    @After
+    public void close() throws SQLException {
+        stat.close();
+        conn.close();
+    }
+
+    @Test
+    public void testTableColumnLowerNowFindLowerCaseColumn()
+            throws SQLException {
+        ResultSet resultSet = stat.executeQuery("select * from test");
+        assertTrue(resultSet.next());
+        assertEquals(1, resultSet.findColumn("id"));
+    }
+
+    @Test
+    public void testTableColumnLowerNowFindUpperCaseColumn()
+            throws SQLException {
+        ResultSet resultSet = stat.executeQuery("select * from test");
+        assertTrue(resultSet.next());
+        assertEquals(1, resultSet.findColumn("ID"));
+    }
+
+    @Test
+    public void testTableColumnLowerNowFindMixedCaseColumn()
+            throws SQLException {
+        ResultSet resultSet = stat.executeQuery("select * from test");
+        assertTrue(resultSet.next());
+        assertEquals(1, resultSet.findColumn("Id"));
+    }
+
+    @Test
+    public void testTableColumnUpperNowFindLowerCaseColumn()
+            throws SQLException {
+        ResultSet resultSet = stat.executeQuery("select * from test");
+        assertTrue(resultSet.next());
+        assertEquals(2, resultSet.findColumn("description"));
+    }
+
+    @Test
+    public void testTableColumnUpperNowFindUpperCaseColumn()
+            throws SQLException {
+        ResultSet resultSet = stat.executeQuery("select * from test");
+        assertTrue(resultSet.next());
+        assertEquals(2, resultSet.findColumn("DESCRIPTION"));
+    }
+
+    @Test
+    public void testTableColumnUpperNowFindMixedCaseColumn()
+            throws SQLException {
+        ResultSet resultSet = stat.executeQuery("select * from test");
+        assertTrue(resultSet.next());
+        assertEquals(2, resultSet.findColumn("Description"));
+    }
+
+    @Test
+    public void testTableColumnMixedNowFindLowerCaseColumn()
+            throws SQLException {
+        ResultSet resultSet = stat.executeQuery("select * from test");
+        assertTrue(resultSet.next());
+        assertEquals(3, resultSet.findColumn("foo"));
+    }
+
+    @Test
+    public void testTableColumnMixedNowFindUpperCaseColumn()
+            throws SQLException {
+        ResultSet resultSet = stat.executeQuery("select * from test");
+        assertTrue(resultSet.next());
+        assertEquals(3, resultSet.findColumn("FOO"));
+    }
+
+    @Test
+    public void testTableColumnMixedNowFindMixedCaseColumn()
+            throws SQLException {
+        ResultSet resultSet = stat.executeQuery("select * from test");
+        assertTrue(resultSet.next());
+        assertEquals(3, resultSet.findColumn("fOo"));
+    }
+
+    @Test
+    public void testSelectWithTableNameAliasNowFindWithoutTableNameAlias()
+            throws SQLException {
+        ResultSet resultSet = stat.executeQuery("select t.id from test as t");
+        assertTrue(resultSet.next());
+        assertEquals(1, resultSet.findColumn("id"));
+    }
+
+    /**
+     * Can't produce a case where column name contains table name
+     * https://www.sqlite.org/c3ref/column_name.html :
+     * "If there is no AS clause then the name of the column is unspecified"
+     */
+    @Test(expected = SQLException.class)
+    public void testSelectWithTableNameAliasNowNotFindWithTableNameAlias()
+            throws SQLException {
+        ResultSet resultSet = stat.executeQuery("select t.id from test as t");
+        assertTrue(resultSet.next());
+        resultSet.findColumn("t.id");
+    }
+
+    @Test
+    public void testSelectWithTableNameNowFindWithoutTableName()
+            throws SQLException {
+        ResultSet resultSet = stat.executeQuery("select test.id from test");
+        assertTrue(resultSet.next());
+        assertEquals(1, resultSet.findColumn("id"));
+    }
+
+    @Test(expected = SQLException.class)
+    public void testSelectWithTableNameNowNotFindWithTableName()
+            throws SQLException {
+        ResultSet resultSet = stat.executeQuery("select test.id from test");
+        assertTrue(resultSet.next());
+        resultSet.findColumn("test.id");
+    }
+
+}


### PR DESCRIPTION
This is a performance boost when using #findColumn a lot.