### PR TITLE
Warning message when readelf is not installed.

### DIFF
--- a/src/main/java/org/sqlite/util/OSInfo.java
+++ b/src/main/java/org/sqlite/util/OSInfo.java
@@ -119,12 +119,19 @@ public class OSInfo
                 String javaHome = System.getProperty("java.home");
                 try {
                     // determine if first JVM found uses ARM hard-float ABI
-                    String[] cmdarray = {"/bin/sh", "-c", "find '" + javaHome +
-                        "' -name 'libjvm.so' | head -1 | xargs readelf -A | " +
-                        "grep 'Tag_ABI_VFP_args: VFP registers'"};
-                    int exitCode = Runtime.getRuntime().exec(cmdarray).waitFor();
-                    if(exitCode == 0)
-                        return translateArchNameToFolderName("armhf");
+                    int exitCode = Runtime.getRuntime().exec("which readelf").waitFor();
+                    if(exitCode == 0) {
+                        String[] cmdarray = {"/bin/sh", "-c", "find '" + javaHome +
+                                "' -name 'libjvm.so' | head -1 | xargs readelf -A | " +
+                                "grep 'Tag_ABI_VFP_args: VFP registers'"};
+                        exitCode = Runtime.getRuntime().exec(cmdarray).waitFor();
+                        if (exitCode == 0) {
+                            return translateArchNameToFolderName("armhf");
+                        }
+                    } else {
+                        System.err.println("WARNING! readelf not found. Cannot check if running on an armhf system, " +
+                                "armel architecture will be presumed.");
+                    }
                 }
                 catch(IOException e) {
                     // ignored: fall back to "arm" arch (soft-float ABI)


### PR DESCRIPTION
On an armhf system with no binutils installed and using a Java prior to version 8, armhf will not be detected and the wrong .so will be unpacked. Unfortunately this results in a crash with a FileNotFoundException, which is confusing (because the file is there and it has the right permissions).
This patch attempts to provide the user with a more meaningful message.