### PR TITLE
Fix JDBC3ResultSet.getBinaryStream()

### DIFF
--- a/src/main/java/org/sqlite/jdbc3/JDBC3ResultSet.java
+++ b/src/main/java/org/sqlite/jdbc3/JDBC3ResultSet.java
@@ -222,7 +222,13 @@ public abstract class JDBC3ResultSet extends CoreResultSet {
      * @see java.sql.ResultSet#getBinaryStream(int)
      */
     public InputStream getBinaryStream(int col) throws SQLException {
-        return new ByteArrayInputStream(getBytes(col));
+        byte[] bytes = getBytes(col);
+        if (bytes != null) {
+            return new ByteArrayInputStream(bytes);
+        }
+        else {
+            return null;
+        }
     }
 
     /**


### PR DESCRIPTION
Bugfix for this issue: https://bitbucket.org/xerial/sqlite-jdbc/issues/163/null-pointer-exception-on-null-input