### PR TITLE
Test and fix bug in execute(String sql)

### DIFF
--- a/src/main/java/org/sqlite/core/CoreStatement.java
+++ b/src/main/java/org/sqlite/core/CoreStatement.java
@@ -69,12 +69,15 @@ public abstract class CoreStatement implements Codes
         if (rs.isOpen())
             throw new SQLException("SQLite JDBC internal error: rs.isOpen() on exec.");
 
+        boolean success = false;
         boolean rc = false;
         try {
             rc = db.execute(this, null);
+            success = true;
         }
         finally {
             resultsWaiting = rc;
+            if (!success) db.finalize(this);
         }
 
         return db.column_count(pointer) != 0;
@@ -94,11 +97,14 @@ public abstract class CoreStatement implements Codes
             throw new SQLException("SQLite JDBC internal error: rs.isOpen() on exec.");
 
         boolean rc = false;
+        boolean success = false;
         try {
             rc = db.execute(sql);
+            success = true;
         }
         finally {
             resultsWaiting = rc;
+            if (!success) db.finalize(this);
         }
 
         return db.column_count(pointer) != 0;

--- a/src/main/java/org/sqlite/core/DB.java
+++ b/src/main/java/org/sqlite/core/DB.java
@@ -844,10 +844,13 @@ public abstract class DB implements Codes
      * @throws SQLException
      */
     public final synchronized int executeUpdate(CoreStatement stmt, Object[] vals) throws SQLException {
-        if (execute(stmt, vals)) {
-            throw new SQLException("query returns results");
+        try {
+            if (execute(stmt, vals)) {
+                throw new SQLException("query returns results");
+            }
+        } finally {
+            reset(stmt.pointer);
         }
-        reset(stmt.pointer);
         return changes();
     }
 

--- a/src/main/java/org/sqlite/jdbc3/JDBC3PreparedStatement.java
+++ b/src/main/java/org/sqlite/jdbc3/JDBC3PreparedStatement.java
@@ -48,8 +48,14 @@ public abstract class JDBC3PreparedStatement extends CorePreparedStatement {
         db.reset(pointer);
         checkParameters();
 
-        resultsWaiting = db.execute(this, batch);
-        return columnCount != 0;
+        boolean success = false;
+        try {
+            resultsWaiting = db.execute(this, batch);
+            success = true;
+            return columnCount != 0;
+        } finally {
+            if (!success) db.reset(pointer);
+        }
     }
 
     /**
@@ -66,7 +72,13 @@ public abstract class JDBC3PreparedStatement extends CorePreparedStatement {
         db.reset(pointer);
         checkParameters();
 
-        resultsWaiting = db.execute(this, batch);
+        boolean success = false;
+        try {
+            resultsWaiting = db.execute(this, batch);
+            success = true;
+        } finally {
+            if (!success) db.reset(pointer);
+        }
         return getResultSet();
     }
 

--- a/src/main/java/org/sqlite/jdbc3/JDBC3Statement.java
+++ b/src/main/java/org/sqlite/jdbc3/JDBC3Statement.java
@@ -57,8 +57,17 @@ public abstract class JDBC3Statement extends CoreStatement {
 
         this.sql = sql;
 
-        db.prepare(this);
-        return exec();
+        boolean success = false;
+        try {
+            db.prepare(this);
+            final boolean result = exec();
+            success = true;
+            return result;
+        } finally {
+            if (!success) {
+                internalClose();
+            }
+        }
     }
 
     /**

--- a/src/main/java/org/sqlite/jdbc3/JDBC3Statement.java
+++ b/src/main/java/org/sqlite/jdbc3/JDBC3Statement.java
@@ -57,17 +57,8 @@ public abstract class JDBC3Statement extends CoreStatement {
 
         this.sql = sql;
 
-        boolean success = false;
-        try {
-            db.prepare(this);
-            final boolean result = exec();
-            success = true;
-            return result;
-        } finally {
-            if (!success) {
-                internalClose();
-            }
-        }
+        db.prepare(this);
+        return exec();
     }
 
     /**


### PR DESCRIPTION
Right now, if execute(String) fails when a transaction is open, then you aren't able to ever roll back the transaction and start again. Replacing "execute" with "executeUpdate" makes the problem go away.

I'm not 100% convinced my fix is right here, but it does make the test pass!