### PR TITLE
Use UTF-8 functions of SQLite to avoid unexpected data type conversions

### DIFF
--- a/src/main/java/org/sqlite/core/NativeDB.java
+++ b/src/main/java/org/sqlite/core/NativeDB.java
@@ -16,6 +16,7 @@
 
 package org.sqlite.core;
 
+import java.io.UnsupportedEncodingException;
 import java.sql.SQLException;
 
 import org.sqlite.Function;
@@ -395,5 +396,23 @@ public final class NativeDB extends DB
      */
     static void throwex(String msg) throws SQLException {
         throw new SQLException(msg);
+    }
+
+    static byte[] stringToUtf8ByteArray(String str) {
+        try {
+            return str.getBytes("UTF-8");
+        }
+        catch (UnsupportedEncodingException e) {
+            throw new RuntimeException("UTF-8 is not supported", e);
+        }
+    }
+
+    static String utf8ByteArrayToString(byte[] utf8bytes) {
+        try {
+            return new String(utf8bytes, "UTF-8");
+        }
+        catch (UnsupportedEncodingException e) {
+            throw new RuntimeException("UTF-8 is not supported", e);
+        }
     }
 }

--- a/src/test/java/org/sqlite/StatementTest.java
+++ b/src/test/java/org/sqlite/StatementTest.java
@@ -2,6 +2,7 @@ package org.sqlite;
 
 import static org.junit.Assert.*;
 
+import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Method;
 import java.sql.BatchUpdateException;
 import java.sql.Connection;
@@ -384,6 +385,30 @@ public class StatementTest
         stat.executeUpdate("CREATE TABLE Foo (KeyId INTEGER, Stuff BLOB)");
     }
 
+    @Test
+    public void bytesTest() throws SQLException, UnsupportedEncodingException {
+        stat.executeUpdate("CREATE TABLE blobs (Blob BLOB)");
+        PreparedStatement prep = conn.prepareStatement("insert into blobs values(?)");
+        
+        String str = "This is a test";
+        byte[] strBytes = str.getBytes("UTF-8");
+        
+        prep.setBytes(1, strBytes);
+        prep.executeUpdate();
+        
+        ResultSet rs = stat.executeQuery("select * from blobs");
+        assertTrue(rs.next());
+
+        byte[] resultBytes = rs.getBytes(1);
+        assertArrayEquals(strBytes, resultBytes);
+        
+        String resultStr = rs.getString(1);
+        assertEquals(str, resultStr);
+
+        byte[] resultBytesAfterConversionToString = rs.getBytes(1);
+        assertArrayEquals(strBytes, resultBytesAfterConversionToString);
+    }
+    
     @Test
     public void dateTimeTest() throws SQLException {
         Date day = new Date(new java.util.Date().getTime());


### PR DESCRIPTION
Also don't use modified UTF-8, see https://github.com/xerial/sqlite-jdbc/issues/61
Convert Java Strings to "unmodified" UTF-8 and vice versa.
Improve out-of-memory handling.

Fixes https://github.com/xerial/sqlite-jdbc/issues/78