### PR TITLE
Fixed date/time handling

### DIFF
--- a/src/main/java/org/sqlite/core/CoreConnection.java
+++ b/src/main/java/org/sqlite/core/CoreConnection.java
@@ -67,7 +67,7 @@ public abstract class CoreConnection {
         SQLiteConfig config = new SQLiteConfig(prop);
         this.dateClass = config.dateClass;
         this.dateMultiplier = config.dateMultiplier;
-        this.dateFormat = FastDateFormat.getInstance(config.dateStringFormat);
+        this.dateFormat = FastDateFormat.getInstance(config.dateStringFormat, java.util.TimeZone.getTimeZone("UTC"));
         this.dateStringFormat = config.dateStringFormat;
         this.datePrecision = config.datePrecision;
         this.transactionMode = config.getTransactionMode();

--- a/src/test/java/org/sqlite/AllTests.java
+++ b/src/test/java/org/sqlite/AllTests.java
@@ -8,6 +8,7 @@ import org.sqlite.util.OSInfoTest;
 @Suite.SuiteClasses({
     BackupTest.class,
     ConnectionTest.class,
+    DateTimeTest.class,
     DBMetaDataTest.class,
     ExtendedCommandTest.class,
     ExtensionTest.class,

--- a/src/test/java/org/sqlite/DateTimeTest.java
+++ b/src/test/java/org/sqlite/DateTimeTest.java
@@ -25,9 +25,12 @@ import org.junit.Test;
 
 public class DateTimeTest
 {
-    // Mon May 23 06:06:21 MSK 2016 = Mon May 23 03:06:21 GMT 2016
+    // Mon May 23 06:06:21.123 MSK 2016 = Mon May 23 03:06:21.123 GMT 2016
     private static final long DATETIME_UNIX = 1463972781L;
+    private static final long DATETIME_MILLISECONDS = 123;
+    private static final long DATETIME_UNIX_HIPRECISION = DATETIME_UNIX * 1000 + DATETIME_MILLISECONDS;
     private static final Date DATETIME = new Date(DATETIME_UNIX * 1000);
+    private static final Date DATETIME_HIPRECISION = new Date(DATETIME_UNIX_HIPRECISION);
 
     private Connection conn;
     private PreparedStatement stat;
@@ -92,6 +95,55 @@ public class DateTimeTest
         ResultSet rs = stat.executeQuery();
         assertTrue(rs.next());
         assertEquals(rs.getLong(1), DATETIME_UNIX);
+        rs.close();
+    }
+
+    @Test
+    public void getDateInt() throws SQLException {
+        SQLiteConfig config = new SQLiteConfig();
+
+        config.setReadOnly(true);
+        config.setDateClass("INTEGER");
+        config.setDatePrecision("SECONDS");
+
+        conn = DriverManager.getConnection("jdbc:sqlite:", config.toProperties());
+        stat = conn.prepareStatement("select " + String.valueOf(DATETIME_UNIX));
+
+        ResultSet rs = stat.executeQuery();
+        assertTrue(rs.next());
+        assertEquals(rs.getDate(1), DATETIME);
+        rs.close();
+    }
+
+    /**
+     * Driver MUST scan date/time in UTC because SQLite's internal date/time format is UTC.
+     *
+     * To test this in UTC timezone use java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone("GMT+3"));
+     */
+    @Test
+    public void getDateJulian() throws SQLException {
+        conn = DriverManager.getConnection("jdbc:sqlite:");
+        stat = conn.prepareStatement("select julianday(" + String.valueOf(DATETIME_UNIX) + ", 'unixepoch', '+' || (" + String.valueOf(DATETIME_MILLISECONDS) + " / 1000.0) || ' seconds')");
+
+        ResultSet rs = stat.executeQuery();
+        assertTrue(rs.next());
+        assertEquals(rs.getDate(1), DATETIME_HIPRECISION);
+        rs.close();
+    }
+
+    /**
+     * Driver MUST scan date/time in UTC because SQLite's internal date/time format is UTC.
+     *
+     * To test this in UTC timezone use java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone("GMT+3"));
+     */
+    @Test
+    public void getDateString() throws SQLException {
+        conn = DriverManager.getConnection("jdbc:sqlite:");
+        stat = conn.prepareStatement("select strftime('%Y-%m-%d %H:%M:%f', " + String.valueOf(DATETIME_UNIX) + ", 'unixepoch', '+' || (" + String.valueOf(DATETIME_MILLISECONDS) + " / 1000.0) || ' seconds')");
+
+        ResultSet rs = stat.executeQuery();
+        assertTrue(rs.next());
+        assertEquals(rs.getDate(1), DATETIME_HIPRECISION);
         rs.close();
     }
 

--- a/src/test/java/org/sqlite/DateTimeTest.java
+++ b/src/test/java/org/sqlite/DateTimeTest.java
@@ -1,0 +1,98 @@
+package org.sqlite;
+
+import static org.junit.Assert.*;
+
+import java.io.ByteArrayInputStream;
+import java.io.UnsupportedEncodingException;
+import java.sql.Connection;
+import java.sql.Date;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.StringTokenizer;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/*
+ * Created by Alexander Galanin <al@galanin.nnov.ru>
+ */
+
+public class DateTimeTest
+{
+    // Mon May 23 06:06:21 MSK 2016 = Mon May 23 03:06:21 GMT 2016
+    private static final long DATETIME_UNIX = 1463972781L;
+    private static final Date DATETIME = new Date(DATETIME_UNIX * 1000);
+
+    private Connection conn;
+    private PreparedStatement stat;
+
+    @After
+    public void close() throws SQLException {
+        stat.close();
+        conn.close();
+    }
+
+    @Test
+    public void setDateUnix() throws SQLException {
+        SQLiteConfig config = new SQLiteConfig();
+
+        config.setReadOnly(true);
+        config.setDateClass("INTEGER");
+        config.setDatePrecision("SECONDS");
+
+        conn = DriverManager.getConnection("jdbc:sqlite:", config.toProperties());
+        stat = conn.prepareStatement("select strftime('%s', ?, 'unixepoch')");
+        stat.setDate(1, DATETIME);
+
+        ResultSet rs = stat.executeQuery();
+        assertTrue(rs.next());
+        assertEquals(rs.getLong(1), DATETIME_UNIX);
+        rs.close();
+    }
+
+    @Test
+    public void setDateJulian() throws SQLException {
+        SQLiteConfig config = new SQLiteConfig();
+
+        config.setReadOnly(true);
+        config.setDateClass("REAL");
+
+        conn = DriverManager.getConnection("jdbc:sqlite:", config.toProperties());
+        stat = conn.prepareStatement("select strftime('%s', ?)");
+        stat.setDate(1, DATETIME);
+
+        ResultSet rs = stat.executeQuery();
+        assertTrue(rs.next());
+        assertEquals(rs.getLong(1), DATETIME_UNIX);
+        rs.close();
+    }
+
+    /**
+     * Driver MUST format date/time in UTC because SQLite's internal date/time format is UTC.
+     *
+     * To test this in UTC timezone use java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone("GMT+3"));
+     */
+    @Test
+    public void setDateText() throws SQLException {
+        SQLiteConfig config = new SQLiteConfig();
+
+        config.setReadOnly(true);
+        config.setDateClass("TEXT");
+
+        conn = DriverManager.getConnection("jdbc:sqlite:", config.toProperties());
+        stat = conn.prepareStatement("select strftime('%s', ?)");
+        stat.setDate(1, DATETIME);
+
+        ResultSet rs = stat.executeQuery();
+        assertTrue(rs.next());
+        assertEquals(rs.getLong(1), DATETIME_UNIX);
+        rs.close();
+    }
+
+}

--- a/src/test/java/org/sqlite/QueryTest.java
+++ b/src/test/java/org/sqlite/QueryTest.java
@@ -18,6 +18,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Date;
+import java.util.TimeZone;
 
 import org.sqlite.date.FastDateFormat;
 
@@ -76,7 +77,7 @@ public class QueryTest
         conn.createStatement().execute("create table sample (start_time datetime)");
 
         Date now = new Date();
-        String date = FastDateFormat.getInstance(SQLiteConfig.DEFAULT_DATE_STRING_FORMAT).format(now);
+        String date = FastDateFormat.getInstance(SQLiteConfig.DEFAULT_DATE_STRING_FORMAT, TimeZone.getTimeZone("UTC")).format(now);
 
         conn.createStatement().execute("insert into sample values(" + now.getTime() + ")");
         conn.createStatement().execute("insert into sample values('" + date + "')");


### PR DESCRIPTION
SQLite's internal date and time functions use UTC time zone. So we need to adjust date/time formatting and scanning in library to always use UTC.