### PR TITLE
Fix crash on addBatch with zero-parameter queries

### DIFF
--- a/src/main/java/org/sqlite/jdbc3/JDBC3PreparedStatement.java
+++ b/src/main/java/org/sqlite/jdbc3/JDBC3PreparedStatement.java
@@ -105,6 +105,10 @@ public abstract class JDBC3PreparedStatement extends CorePreparedStatement {
     public void addBatch() throws SQLException {
         checkOpen();
         batchPos += paramCount;
+        batchQueryCount++;
+        if (batch == null) {
+            batch = new Object[0];
+        }
         if (batchPos + paramCount > batch.length) {
             Object[] nb = new Object[batch.length * 2];
             System.arraycopy(batch, 0, nb, 0, batch.length);

--- a/src/main/java/org/sqlite/jdbc3/JDBC3PreparedStatement.java
+++ b/src/main/java/org/sqlite/jdbc3/JDBC3PreparedStatement.java
@@ -107,7 +107,7 @@ public abstract class JDBC3PreparedStatement extends CorePreparedStatement {
         batchPos += paramCount;
         batchQueryCount++;
         if (batch == null) {
-            batch = new Object[0];
+            batch = new Object[paramCount];
         }
         if (batchPos + paramCount > batch.length) {
             Object[] nb = new Object[batch.length * 2];

--- a/src/test/java/org/sqlite/PrepStmtTest.java
+++ b/src/test/java/org/sqlite/PrepStmtTest.java
@@ -448,6 +448,21 @@ public class PrepStmtTest
     }
 
     @Test
+    public void batchZeroParams() throws Exception {
+        stat.executeUpdate("create table test (c1);");
+        PreparedStatement prep = conn.prepareStatement("insert into test values (5);");
+        for (int i = 0; i < 10; i++) {
+            prep.addBatch();
+        }
+        assertArrayEq(new int[] { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 }, prep.executeBatch());
+        prep.close();
+        ResultSet rs = stat.executeQuery("select count(*) from test;");
+        assertTrue(rs.next());
+        assertEquals(rs.getInt(1), 10);
+        rs.close();
+    }
+
+    @Test
     public void paramMetaData() throws SQLException {
         PreparedStatement prep = conn.prepareStatement("select ?,?,?,?;");
         assertEquals(prep.getParameterMetaData().getParameterCount(), 4);


### PR DESCRIPTION
Currently, calling `addBatch()` on a prepared statement where the query has no parameters causes a NullPointerException. This PR fixes that.

Of course calling `addBatch()` this way is not very useful when using JDBC directly, but can occur in higher-level wrapper libraries that don't special-case the zero parameters case.

Other JDBC drivers (I checked MySQL and PostgreSQL) work just fine even when there are no parameters in the query. The JDBC spec doesn't mention this case specifically.

This probably also fixes #48. There is still no error thrown when some parameters are missing (and there probably should be), but that was the case before as well.