### PR TITLE
implementing sqlite3_busy_handler api function

### DIFF
--- a/src/main/java/org/sqlite/BusyHandler.java
+++ b/src/main/java/org/sqlite/BusyHandler.java
@@ -1,0 +1,62 @@
+package org.sqlite;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+/**
+ *
+ * https://www.sqlite.org/c3ref/busy_handler.html
+ */
+public abstract class BusyHandler {
+    
+    /**
+     * commit the busy handler for the connection.
+     *
+     * @param conn the SQLite connection
+     * @param busyHandler the busyHandler
+     * @throws SQLException
+     */
+    private static void commitHandler(Connection conn, BusyHandler busyHandler) throws SQLException {
+        
+        if (conn == null || !(conn instanceof SQLiteConnection)) {
+            throw new SQLException("connection must be to an SQLite db");
+        }
+        
+        if (conn.isClosed()) {
+            throw new SQLException("connection closed");
+        }
+        
+        SQLiteConnection sqliteConnection = (SQLiteConnection) conn;
+        sqliteConnection.db().busy_handler(busyHandler);
+    }
+    
+    /**
+     * Sets a busy handler for the connection.
+     *
+     * @param conn the SQLite connection
+     * @param busyHandler the busyHandler
+     * @throws SQLException
+     */
+    public static final void setHandler(Connection conn, BusyHandler busyHandler) throws SQLException {
+        commitHandler(conn, busyHandler);
+    }
+
+    /**
+     * Clears any busy handler registered with the connection.
+     *
+     * @param conn the SQLite connection
+     * @throws SQLException
+     */
+    public static final void clearHandler(Connection conn) throws SQLException {
+        commitHandler(conn, null);
+    }
+
+    /**
+     * https://www.sqlite.org/c3ref/busy_handler.html
+     *
+     * @param nbPrevInvok number of times that the busy handler has been invoked previously for the same locking event
+     * @throws SQLException
+     * @return If the busy callback returns 0, then no additional attempts are made to access the database and SQLITE_BUSY is returned to the application. If the callback returns non-zero, then another attempt is made to access the database and the cycle repeats.
+     */
+    protected abstract int callback(int nbPrevInvok) throws SQLException;
+}

--- a/src/main/java/org/sqlite/core/DB.java
+++ b/src/main/java/org/sqlite/core/DB.java
@@ -15,6 +15,7 @@
  */
 package org.sqlite.core;
 
+import org.sqlite.BusyHandler;
 import java.sql.BatchUpdateException;
 import java.sql.SQLException;
 import java.util.HashMap;
@@ -68,6 +69,15 @@ public abstract class DB implements Codes
      * @see <a href="http://www.sqlite.org/c3ref/busy_timeout.html">http://www.sqlite.org/c3ref/busy_timeout.html</a>
      */
     public abstract void busy_timeout(int ms) throws SQLException;
+    
+    /**
+     * Sets a <a href="http://www.sqlite.org/c3ref/busy_handler.html">busy handler</a> that sleeps
+     * for a specified amount of time when a table is locked.
+     * @param busyHandler
+     * @throws SQLException
+     * @see <a href="http://www.sqlite.org/c3ref/busy_handler.html">http://www.sqlite.org/c3ref/busy_timeout.html</a>
+     */
+    public abstract void busy_handler(BusyHandler busyHandler) throws SQLException;
 
     /**
      * Return English-language text that describes the error as either UTF-8 or UTF-16.

--- a/src/main/java/org/sqlite/core/NativeDB.java
+++ b/src/main/java/org/sqlite/core/NativeDB.java
@@ -16,6 +16,7 @@
 
 package org.sqlite.core;
 
+import org.sqlite.BusyHandler;
 import java.io.UnsupportedEncodingException;
 import java.sql.SQLException;
 
@@ -103,6 +104,12 @@ public final class NativeDB extends DB
      */
     @Override
     public native synchronized void busy_timeout(int ms);
+    
+    /**
+     * @see org.sqlite.core.DB#busy_handler(int)
+     */
+    @Override
+    public native synchronized void busy_handler(BusyHandler busyHandler);
 
     /**
      * @see org.sqlite.core.DB#prepare(java.lang.String)

--- a/src/test/java/org/sqlite/AllTests.java
+++ b/src/test/java/org/sqlite/AllTests.java
@@ -30,6 +30,7 @@ import org.sqlite.util.OSInfoTest;
     JSON1Test.class,
     ProgressHandlerTest.class,
     BusyHandlerTest.class
+    
 })
 public class AllTests {
 // runs all Tests

--- a/src/test/java/org/sqlite/AllTests.java
+++ b/src/test/java/org/sqlite/AllTests.java
@@ -28,7 +28,8 @@ import org.sqlite.util.OSInfoTest;
     TransactionTest.class,
     UDFTest.class,
     JSON1Test.class,
-    ProgressHandlerTest.class
+    ProgressHandlerTest.class,
+    BusyHandlerTest.class
 })
 public class AllTests {
 // runs all Tests

--- a/src/test/java/org/sqlite/BusyHandlerTest.java
+++ b/src/test/java/org/sqlite/BusyHandlerTest.java
@@ -1,0 +1,181 @@
+package org.sqlite;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import static org.junit.Assert.assertEquals;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class BusyHandlerTest {
+    private Connection conn;
+    private Statement stat;
+
+    @Before
+    public void connect() throws Exception {
+        conn = DriverManager.getConnection("jdbc:sqlite:test.db");
+        stat = conn.createStatement();
+    }
+
+    @After
+    public void close() throws SQLException {
+        stat.close();
+        conn.close();
+    }
+
+    public class BusyWork extends Thread {
+        private final Connection conn;
+        private final Statement stat;
+        
+        public BusyWork() throws Exception {
+            conn = DriverManager.getConnection("jdbc:sqlite:test.db");
+            stat = conn.createStatement();
+            stat.setQueryTimeout(10);
+        }
+        
+        @Override
+        public void run(){
+
+            try {
+                synchronized(this) {
+                    // Generate some work for the sqlite vm
+                    stat.executeUpdate("drop table if exists foo;");
+                    stat.executeUpdate("create table foo (id integer);");
+
+                    int i = 0;
+                    while (i<10000) {
+                        String stmt = "insert into foo (id) values (" + i + ")";
+                        stat.addBatch(stmt);
+                        i++;
+                    }
+                }
+            } catch (SQLException ex) {System.out.println("HERE"+ex.toString());}
+
+            try {
+                stat.executeBatch();
+            } catch (SQLException ex) {System.out.println("BLOB"+ex.toString());}
+        }
+    }
+    
+    private void workWork() throws SQLException, InterruptedException {
+        // I let busyWork inject first so it can busy the db
+        Thread.sleep(1000);
+        
+        // Generate some work for the sqlite vm
+        int i = 0;
+        while (i<100) {
+            stat.executeQuery("insert into foo (id) values (" + i + ")");
+            i++;
+        }
+    }
+
+    @Test
+    public void basicBusyHandler() throws Exception {
+        final int[] calls = {0};
+        BusyHandler.setHandler(conn, new BusyHandler() {
+            @Override
+            protected int callback(int nbPrevInvok) throws SQLException {
+                assertTrue(calls[0] == nbPrevInvok);
+                calls[0]++;
+                
+                if (nbPrevInvok <= 1) {
+                    return 1;
+                } else {
+                    return 0;
+                }
+            }
+        });
+        
+        BusyWork busyWork = new BusyWork();
+        busyWork.start();
+        
+        // I let busyWork prepare a huge insert
+        Thread.sleep(1000);
+        
+        synchronized(busyWork){ 
+            try{
+                workWork();
+            } catch(SQLException ex) {
+                assertTrue(ex.getErrorCode() == SQLiteErrorCode.SQLITE_BUSY.code);
+            }
+        }
+        
+        busyWork.interrupt();
+        assertTrue(calls[0] == 3);
+    }
+
+    @Test
+    public void testUnregister() throws Exception {
+        final int[] calls = {0};
+        BusyHandler.setHandler(conn, new BusyHandler() {
+            @Override
+            protected int callback(int nbPrevInvok) throws SQLException {
+                assertTrue(calls[0] == nbPrevInvok);
+                calls[0]++;
+                
+                if (nbPrevInvok <= 1) {
+                    return 1;
+                } else {
+                    return 0;
+                }
+            }
+        });
+        
+        BusyWork busyWork = new BusyWork();
+        busyWork.start();
+        // I let busyWork prepare a huge insert
+        Thread.sleep(1000);
+        synchronized(busyWork){ 
+            try{
+                workWork();
+            } catch(SQLException ex) {
+                assertTrue(ex.getErrorCode() == SQLiteErrorCode.SQLITE_BUSY.code);
+            }
+        }
+        assertTrue(calls[0] == 3);
+        
+        int totalCalls = calls[0];
+        BusyHandler.clearHandler(conn);
+        busyWork = new BusyWork();
+        busyWork.start();
+        // I let busyWork prepare a huge insert
+        Thread.sleep(1000);
+        synchronized(busyWork){ 
+            try{
+                workWork();
+            } catch(SQLException ex) {
+                assertTrue(ex.getErrorCode() == SQLiteErrorCode.SQLITE_BUSY.code);
+            }
+        }
+    
+        busyWork.interrupt();
+        assertEquals(totalCalls, calls[0]);
+    }
+
+    @Test
+    public void testInterrupt() throws Exception {
+
+        try {
+            BusyHandler.setHandler(conn, new BusyHandler() {
+                @Override
+                protected int callback(int nbPrevInvok) throws SQLException {
+                    return 1;
+                }
+            });
+            workWork();
+        } catch (SQLException ex) {
+            // Expected error
+            return;
+        }
+        // Progress function throws, not reached
+        fail();
+    }
+}


### PR DESCRIPTION
Hello,

I have implement sqlite3_busy_handler (https://www.sqlite.org/c3ref/busy_handler.html) for sqlite-jdbc.
A JAVA callback can be called on a BUSY_TIMEOUT error.
As explained in sqlite doc, sqlite will retry statement execution if the callback returns 0.

Could you please help me to integrate this to the main fork?

Thanks,
Hugo