### PR TITLE
Fix build problem for SQLite 3.14.0 onwards

### DIFF
--- a/src/main/ext/extension-functions.c
+++ b/src/main/ext/extension-functions.c
@@ -140,8 +140,11 @@ SQLITE_EXTENSION_INIT1
 #include <stdlib.h>
 #include <assert.h>
 
+/* The defined changed from _SQLITEINT_H_ to SQLITEINT_H in SQLite 3.14.0. */
 #ifndef _SQLITEINT_H_
+#ifndef SQLITEINT_H
 #include "sqliteInt.h"
+#endif
 #endif
 
 #ifndef _MAP_H_


### PR DESCRIPTION
The preprocessor variable _SQLITEINT_H_ was renamed to SQLITEINT_H
with SQLite 3.14.0 (http://www.sqlite.org/src/info/5471aca0158851d3).

Only if neither is defined attempt to include sqliteInt.h.