### PR TITLE
fixed NPE in getIndexInfo() for expression index

### DIFF
--- a/src/main/java/org/sqlite/jdbc3/JDBC3DatabaseMetaData.java
+++ b/src/main/java/org/sqlite/jdbc3/JDBC3DatabaseMetaData.java
@@ -1585,10 +1585,17 @@ public abstract class JDBC3DatabaseMetaData extends org.sqlite.core.CoreDatabase
 
                     StringBuilder sqlRow = new StringBuilder();
 
+                    String colName = rs.getString(3);
                     sqlRow.append("select ").append(Integer.toString(1 - (Integer) currentIndex.get(1))).append(" as un,'")
                             .append(escape(indexName)).append("' as n,")
-                            .append(Integer.toString(rs.getInt(1) + 1)).append(" as op,'")
-                            .append(escape(rs.getString(3))).append("' as cn");
+                            .append(Integer.toString(rs.getInt(1) + 1)).append(" as op,");
+                    if (colName == null) { // expression index
+                      sqlRow.append("null");
+                    }
+                    else {
+                      sqlRow.append("'").append(escape(colName)).append("'");
+                    }
+                    sqlRow.append(" as cn");
 
                     unionAll.add(sqlRow.toString());
                 }

--- a/src/test/java/org/sqlite/DBMetaDataTest.java
+++ b/src/test/java/org/sqlite/DBMetaDataTest.java
@@ -689,6 +689,19 @@ public class DBMetaDataTest
 
 
     @Test
+    public void getIndexInfoIndexedSingleExpr() throws SQLException {
+        stat.executeUpdate("create table testindex (id integer primary key, fn float default 0.0, sn not null);");
+        stat.executeUpdate("create index testindex_idx on testindex (sn, fn/2);");
+
+        ResultSet rs = meta.getIndexInfo(null,null,"testindex",false,false);
+        ResultSetMetaData rsmd = rs.getMetaData();
+
+        assertNotNull(rs);
+        assertNotNull(rsmd);
+    }
+
+
+    @Test
     public void getIndexInfoIndexedMulti() throws SQLException {
         stat.executeUpdate("create table testindex (id integer primary key, fn float default 0.0, sn not null);");
         stat.executeUpdate("create index testindex_idx on testindex (sn);");


### PR DESCRIPTION
If expression is used instead of column, then null-name is returned by sqlite