### PR TITLE
seems to make the latest code faster by reducing the back-n-forth between JNI and Java.

### DIFF
--- a/src/main/java/org/sqlite/core/DB.java
+++ b/src/main/java/org/sqlite/core/DB.java
@@ -373,6 +373,7 @@ public abstract class DB implements Codes
      * @see <a href="http://www.sqlite.org/c3ref/column_name.html">http://www.sqlite.org/c3ref/column_name.html</a>
      */
     public abstract String column_name(long stmt, int col) throws SQLException;
+    protected abstract byte[] column_name_utf8(long stmt, int col) throws SQLException;
 
     /**
      * @param stmt Pointer to the statement.
@@ -382,6 +383,7 @@ public abstract class DB implements Codes
      * @see <a href="http://www.sqlite.org/c3ref/column_blob.html">http://www.sqlite.org/c3ref/column_blob.html</a>
      */
     public abstract String column_text(long stmt, int col) throws SQLException;
+    protected abstract byte[] column_text_utf8(long stmt, int col) throws SQLException;
 
     /**
      * @param stmt Pointer to the statement.

--- a/src/main/java/org/sqlite/core/NativeDB.c
+++ b/src/main/java/org/sqlite/core/NativeDB.c
@@ -772,10 +772,12 @@ JNIEXPORT jstring JNICALL Java_org_sqlite_core_NativeDB_column_1table_1name(
     return utf8BytesToString(env, str, strlen(str));
 }
 
-JNIEXPORT jstring JNICALL Java_org_sqlite_core_NativeDB_column_1name(
+JNIEXPORT jstring JNICALL Java_org_sqlite_core_NativeDB_column_1name_1utf8(
         JNIEnv *env, jobject this, jlong stmt, jint col)
 {
     const char *str;
+    int length;
+    jbyteArray jBlob;
 
     if (!stmt)
     {
@@ -785,15 +787,23 @@ JNIEXPORT jstring JNICALL Java_org_sqlite_core_NativeDB_column_1name(
 
     str = sqlite3_column_name(toref(stmt), col);
     if (!str) return NULL;
-    return utf8BytesToString(env, str, strlen(str));
+
+    length = strlen(str);
+    jBlob = (*env)->NewByteArray(env, length);
+    if (!jBlob) { throwex_outofmemory(env); return 0; }
+
+    (*env)->SetByteArrayRegion(env, jBlob, (jsize) 0, (jsize) length, (const jbyte*) str);
+
+    return jBlob;
 }
 
-JNIEXPORT jstring JNICALL Java_org_sqlite_core_NativeDB_column_1text(
+JNIEXPORT jstring JNICALL Java_org_sqlite_core_NativeDB_column_1text_1utf8(
         JNIEnv *env, jobject this, jlong stmt, jint col)
 {
     sqlite3 *db;
     const char *bytes;
     int nbytes;
+    jbyteArray jBlob;
 
     db = gethandle(env, this);
     if (!db)
@@ -816,8 +826,17 @@ JNIEXPORT jstring JNICALL Java_org_sqlite_core_NativeDB_column_1text(
         throwex_outofmemory(env);
         return NULL;
     }
+    if (!bytes) {
+        return NULL;
+    }
 
-    return utf8BytesToString(env, bytes, nbytes);
+    jBlob = (*env)->NewByteArray(env, nbytes);
+    if (!jBlob) { throwex_outofmemory(env); return 0; }
+
+    (*env)->SetByteArrayRegion(env, jBlob, (jsize) 0, (jsize) nbytes, (const jbyte*) bytes);
+
+    return jBlob;
+
 }
 
 JNIEXPORT jbyteArray JNICALL Java_org_sqlite_core_NativeDB_column_1blob(

--- a/src/main/java/org/sqlite/core/NativeDB.java
+++ b/src/main/java/org/sqlite/core/NativeDB.java
@@ -200,13 +200,36 @@ public final class NativeDB extends DB
      * @see org.sqlite.core.DB#column_name(long, int)
      */
     @Override
-    public native synchronized String column_name(long stmt, int col);
+    public synchronized String column_name(long stmt, int col)
+    {
+        try {
+            return new String(column_name_utf8(stmt, col), "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    @Override
+    protected native synchronized byte[] column_name_utf8(long stmt, int col);
 
     /**
      * @see org.sqlite.core.DB#column_text(long, int)
      */
     @Override
-    public native synchronized String column_text(long stmt, int col);
+    public synchronized String column_text(long stmt, int col)
+    {
+        try {
+            byte[] bytes = column_text_utf8(stmt, col);
+            if (bytes == null) {
+                return null;
+            }
+            return new String(bytes, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
+        }        
+    }
+
+    @Override
+    public native synchronized byte[] column_text_utf8(long stmt, int col);
 
     /**
      * @see org.sqlite.core.DB#column_blob(long, int)


### PR DESCRIPTION
re: https://github.com/xerial/sqlite-jdbc/issues/160

On my MacBook Pro,
**3.8.11.2**
> Time to create & insert: 6872 ms
> Time to select: 8963 ms
> Time to select & get resultset values: 10279 ms

**3.14.2**
> Time to create & insert: 6654 ms
> Time to select: 11362 ms
> Time to select & get resultset values: 14068 ms
> 

**3.14.2.1-SNAPSHOT**
> Time to create & insert: 6527 ms
> Time to select: 8942 ms
> Time to select & get resultset values: 10936 ms
> 


