### PR TITLE
Check if pointer is valid before call to reset()

### DIFF
--- a/src/main/java/org/sqlite/core/DB.java
+++ b/src/main/java/org/sqlite/core/DB.java
@@ -864,7 +864,7 @@ public abstract class DB implements Codes
                 throw new SQLException("query returns results");
             }
         } finally {
-            reset(stmt.pointer);
+            if (stmt.pointer != 0) reset(stmt.pointer);
         }
         return changes();
     }

--- a/src/test/java/org/sqlite/PrepStmtTest.java
+++ b/src/test/java/org/sqlite/PrepStmtTest.java
@@ -650,6 +650,7 @@ public class PrepStmtTest
             PreparedStatement statement = conn.prepareStatement("insert into foo values(?);");
             statement.setInt(1, 1);
             statement.executeUpdate();
+            fail("expected exception");
         } catch (SQLException e) {
             assertEquals(SQLiteErrorCode.SQLITE_CONSTRAINT.code, e.getErrorCode());
         }

--- a/src/test/java/org/sqlite/PrepStmtTest.java
+++ b/src/test/java/org/sqlite/PrepStmtTest.java
@@ -627,7 +627,7 @@ public class PrepStmtTest
     }
 
     @Test
-    public void constraintErrorCode() throws SQLException {
+    public void constraintErrorCodeExecute() throws SQLException {
         assertEquals(0, stat.executeUpdate("create table foo (id integer, CONSTRAINT U_ID UNIQUE (id));"));
         assertEquals(1, stat.executeUpdate("insert into foo values(1);"));
         // try to insert a row with duplicate id
@@ -636,6 +636,20 @@ public class PrepStmtTest
             statement.setInt(1, 1);
             statement.execute();
             fail("expected exception");
+        } catch (SQLException e) {
+            assertEquals(SQLiteErrorCode.SQLITE_CONSTRAINT.code, e.getErrorCode());
+        }
+    }
+
+    @Test
+    public void constraintErrorCodeExecuteUpdate() throws SQLException {
+        assertEquals(0, stat.executeUpdate("create table foo (id integer, CONSTRAINT U_ID UNIQUE (id));"));
+        assertEquals(1, stat.executeUpdate("insert into foo values(1);"));
+        // try to insert a row with duplicate id
+        try {
+            PreparedStatement statement = conn.prepareStatement("insert into foo values(?);");
+            statement.setInt(1, 1);
+            statement.executeUpdate();
         } catch (SQLException e) {
             assertEquals(SQLiteErrorCode.SQLITE_CONSTRAINT.code, e.getErrorCode());
         }


### PR DESCRIPTION
Similar to #166, but for `executeUpdate()`