### PR TITLE
Adding docker build for Alpine Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,10 +105,13 @@ win64: $(SQLITE_UNPACKED) jni-header
 	./docker/dockcross-windows-x64 bash -c 'make clean-native native CROSS_PREFIX=x86_64-w64-mingw32.static- OS_NAME=Windows OS_ARCH=x86_64'
 
 linux32: $(SQLITE_UNPACKED) jni-header
-	docker run -ti -v $$PWD:/work xerial/centos5-linux-x86 bash -c 'make clean-native native OS_NAME=Linux OS_ARCH=x86'
+	docker run --rm -ti -v $$PWD:/work xerial/centos5-linux-x86 bash -c 'make clean-native native OS_NAME=Linux OS_ARCH=x86'
 
 linux64: $(SQLITE_UNPACKED) jni-header
-	docker run -ti -v $$PWD:/work xerial/centos5-linux-x86_64 bash -c 'make clean-native native OS_NAME=Linux OS_ARCH=x86_64'
+	docker run --rm -ti -v $$PWD:/work xerial/centos5-linux-x86_64 bash -c 'make clean-native native OS_NAME=Linux OS_ARCH=x86_64'
+
+alpine-linux64: $(SQLITE_UNPACKED) jni-header
+	docker run --rm -ti -v $$PWD:/work xerial/alpine-linux-x86_64 bash -c 'make clean-native native OS_NAME=Linux OS_ARCH=x86_64'
 
 linux-arm: $(SQLITE_UNPACKED) jni-header
 	./docker/dockcross-armv5 bash -c 'make clean-native native CROSS_PREFIX=arm-linux-gnueabi- OS_NAME=Linux OS_ARCH=arm'
@@ -138,7 +141,10 @@ clean-tests:
 	rm -rf $(TARGET)/{surefire*,testdb.jar*}
 
 docker-linux64:
-	docker build -f docker/Dockerfile.linux_x86_64 -t xerial/centos5-linux-x86-64 .
+	docker build -f docker/Dockerfile.linux_x86_64 -t xerial/centos5-linux-x86_64 .
 
 docker-linux32:
 	docker build -f docker/Dockerfile.linux_x86 -t xerial/centos5-linux-x86 .
+
+docker-alpine-linux64:
+	docker build -f docker/Dockerfile.alpine-linux_x86_64 -t xerial/alpine-linux-x86_64 .

--- a/docker/Dockerfile.alpine-linux_x86_64
+++ b/docker/Dockerfile.alpine-linux_x86_64
@@ -1,0 +1,6 @@
+FROM alpine
+MAINTAINER Taro L. Saito <leo@xerial.org>
+
+RUN apk --update add bash gcc make perl libc-dev
+
+WORKDIR /work


### PR DESCRIPTION
In my project I'm using Alpine docker java image.
Alpine is using libc instead of glibc, which gives these errors:

> [22:07:23 WARN]: Failed to load native library:sqlite-3.15.1-fb339d95-503e-4709-89aa-514bc537aa5c-libsqlitejdbc.so. osinfo: Linux/x86_64
[22:07:23 WARN]: java.lang.UnsatisfiedLinkError: /tmp/sqlite-3.15.1-fb339d95-503e-4709-89aa-514bc537aa5c-libsqlitejdbc.so: Error relocating /tmp/sqlite-3.15.1-fb339d95-503e-4709-89aa-514bc537aa5c-libsqlitejdbc.so: __isnan: symbol not found
[22:07:23 WARN]: java.lang.UnsatisfiedLinkError: org.sqlite.core.NativeDB._open_utf8([BI)V
[22:07:23 WARN]: 	at org.sqlite.core.NativeDB._open_utf8(Native Method)
[22:07:23 WARN]: 	at org.sqlite.core.NativeDB._open(NativeDB.java:71)
[22:07:23 WARN]: 	at org.sqlite.core.DB.open(DB.java:174)
[22:07:23 WARN]: 	at org.sqlite.core.CoreConnection.open(CoreConnection.java:220)
[22:07:23 WARN]: 	at org.sqlite.core.CoreConnection.<init>(CoreConnection.java:76)
[22:07:23 WARN]: 	at org.sqlite.jdbc3.JDBC3Connection.<init>(JDBC3Connection.java:24)
[22:07:23 WARN]: 	at org.sqlite.jdbc4.JDBC4Connection.<init>(JDBC4Connection.java:24)
[22:07:23 WARN]: 	at org.sqlite.SQLiteConnection.<init>(SQLiteConnection.java:45)
[22:07:23 WARN]: 	at org.sqlite.JDBC.createConnection(JDBC.java:114)
[22:07:23 WARN]: 	at org.sqlite.JDBC.connect(JDBC.java:88)

In my use case I replaced the native in my jar with the one I compiled using the alpine docker image which fixed my error.
