### PR TITLE
Fixes case-sensitivity of primary keys - see issue #219

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ src/main/resources/org/ibex/nestedvm/*.o
 atlassian-ide-plugin.xml
 .classpath
 .project
+.settings/
 .DS_Store

--- a/src/main/java/org/sqlite/jdbc3/JDBC3DatabaseMetaData.java
+++ b/src/main/java/org/sqlite/jdbc3/JDBC3DatabaseMetaData.java
@@ -1887,7 +1887,7 @@ public abstract class JDBC3DatabaseMetaData extends org.sqlite.core.CoreDatabase
 
                 Matcher matcher = PK_NAMED_PATTERN.matcher(rs.getString(1));
                 if (matcher.find()){
-                    pkName = '\'' + escape(matcher.group(1).toLowerCase()) + '\'';
+                    pkName = '\'' + escape(matcher.group(1)) + '\'';
                     pkColumns = matcher.group(2).split(",");
                 }
                 else {
@@ -1907,7 +1907,7 @@ public abstract class JDBC3DatabaseMetaData extends org.sqlite.core.CoreDatabase
 
                 if (pkColumns != null)
                     for (int i = 0; i < pkColumns.length; i++) {
-                        pkColumns[i] = pkColumns[i].toLowerCase().trim();
+                        pkColumns[i] = pkColumns[i].trim();
                     }
             }
             finally {

--- a/src/main/java/org/sqlite/jdbc3/JDBC3DatabaseMetaData.java
+++ b/src/main/java/org/sqlite/jdbc3/JDBC3DatabaseMetaData.java
@@ -1326,6 +1326,9 @@ public abstract class JDBC3DatabaseMetaData extends org.sqlite.core.CoreDatabase
         }
 
         String pkName = pkFinder.getName();
+        if (pkName != null) {
+        	pkName = "'" + pkName + "'";
+        }
 
         for (int i = 0; i < columns.length; i++) {
             if (i > 0) sql.append(" union ");
@@ -1887,7 +1890,10 @@ public abstract class JDBC3DatabaseMetaData extends org.sqlite.core.CoreDatabase
 
                 Matcher matcher = PK_NAMED_PATTERN.matcher(rs.getString(1));
                 if (matcher.find()){
-                    pkName = '\'' + escape(matcher.group(1)) + '\'';
+                    pkName = escape(matcher.group(1));
+                    if (pkName.length() > 2 && pkName.startsWith("`") && pkName.endsWith("`")) {
+                    	pkName = pkName.substring(1, pkName.length() - 1);
+                    }
                     pkColumns = matcher.group(2).split(",");
                 }
                 else {
@@ -1905,10 +1911,15 @@ public abstract class JDBC3DatabaseMetaData extends org.sqlite.core.CoreDatabase
                     }
                 }
 
-                if (pkColumns != null)
+                if (pkColumns != null) {
                     for (int i = 0; i < pkColumns.length; i++) {
                         pkColumns[i] = pkColumns[i].trim();
+                        if (pkColumns[i].length() > 2 && pkColumns[i].startsWith("`") && pkColumns[i].endsWith("`")) {
+                        	// unquote to be consistent with column names returned by getColumns()
+                        	pkColumns[i] = pkColumns[i].substring(1, pkColumns[i].length() - 1);
+                        }
                     }
+                }
             }
             finally {
                 try {

--- a/src/test/java/org/sqlite/DBMetaDataTest.java
+++ b/src/test/java/org/sqlite/DBMetaDataTest.java
@@ -526,6 +526,60 @@ public class DBMetaDataTest
         rs = meta.getPrimaryKeys(null, null, "view_nopk");
         assertFalse(rs.next());
     }
+    
+    @Test
+    public void moreOfgetColumns() throws SQLException {
+        ResultSet rs;
+
+        stat.executeUpdate("create table tabcols1 (col1, col2);");
+        // mixed-case table, column and primary key names
+        stat.executeUpdate("CREATE TABLE TabCols2 (Col1, Col2);");
+        // quoted table, column and primary key names
+        stat.executeUpdate("CREATE TABLE `TabCols3` (`Col1`, `Col2`);");
+        
+        rs = meta.getColumns(null, null, "tabcols1", "%");
+        assertTrue(rs.next());
+        assertEquals(rs.getString("TABLE_NAME"), "tabcols1");
+        assertEquals(rs.getString("COLUMN_NAME"), "col1");
+        assertEquals(rs.getInt("DATA_TYPE"), Types.VARCHAR);
+        assertEquals(rs.getString("IS_NULLABLE"), "YES");
+        assertEquals(rs.getString("COLUMN_DEF"), null);
+        assertEquals(rs.getString("IS_AUTOINCREMENT"), "NO");
+        assertTrue(rs.next());
+        assertEquals(rs.getString("TABLE_NAME"), "tabcols1");
+        assertEquals(rs.getString("COLUMN_NAME"), "col2");
+        assertEquals(rs.getInt("DATA_TYPE"), Types.VARCHAR);
+        assertFalse(rs.next());
+        
+        rs = meta.getColumns(null, null, "TabCols2", "%");
+        assertTrue(rs.next());
+        assertEquals(rs.getString("TABLE_NAME"), "TabCols2");
+        assertEquals(rs.getString("COLUMN_NAME"), "Col1");
+        assertEquals(rs.getInt("DATA_TYPE"), Types.VARCHAR);
+        assertEquals(rs.getString("IS_NULLABLE"), "YES");
+        assertEquals(rs.getString("COLUMN_DEF"), null);
+        assertEquals(rs.getString("IS_AUTOINCREMENT"), "NO");
+        assertTrue(rs.next());
+        assertEquals(rs.getString("TABLE_NAME"), "TabCols2");
+        assertEquals(rs.getString("COLUMN_NAME"), "Col2");
+        assertEquals(rs.getInt("DATA_TYPE"), Types.VARCHAR);
+        assertFalse(rs.next());
+        
+        rs = meta.getColumns(null, null, "TabCols3", "%");
+        assertTrue(rs.next());
+        assertEquals(rs.getString("TABLE_NAME"), "TabCols3");
+        assertEquals(rs.getString("COLUMN_NAME"), "Col1");
+        assertEquals(rs.getInt("DATA_TYPE"), Types.VARCHAR);
+        assertEquals(rs.getString("IS_NULLABLE"), "YES");
+        assertEquals(rs.getString("COLUMN_DEF"), null);
+        assertEquals(rs.getString("IS_AUTOINCREMENT"), "NO");
+        assertTrue(rs.next());
+        assertEquals(rs.getString("TABLE_NAME"), "TabCols3");
+        assertEquals(rs.getString("COLUMN_NAME"), "Col2");
+        assertEquals(rs.getInt("DATA_TYPE"), Types.VARCHAR);
+        assertFalse(rs.next());
+        
+    }
 
     @Test
     public void columnOrderOfgetPrimaryKeys() throws SQLException {
@@ -541,6 +595,8 @@ public class DBMetaDataTest
                 "\r\nCONSTraint\r\nnamed  primary\r\n\t\t key   (col3, col2  ));");
         // mixed-case table, column and primary key names
         stat.executeUpdate("CREATE TABLE Pk5 (Col1, Col2, Col3, Col4, CONSTRAINT NamedPk PRIMARY KEY (Col3, Col2));");
+        // quoted table, column and primary key names
+        stat.executeUpdate("CREATE TABLE `Pk6` (`Col1`, `Col2`, `Col3`, `Col4`, CONSTRAINT `NamedPk` PRIMARY KEY (`Col3`, `Col2`));");
         
         rs = meta.getPrimaryKeys(null, null, "nopk");
         assertFalse(rs.next());
@@ -596,10 +652,26 @@ public class DBMetaDataTest
         
         rs = meta.getPrimaryKeys(null, null, "Pk5");
         assertTrue(rs.next());
+        assertEquals(rs.getString("TABLE_NAME"), "Pk5");
         assertEquals(rs.getString("COLUMN_NAME"), "Col2");
         assertEquals(rs.getString("PK_NAME"), "NamedPk");
         assertEquals(rs.getInt("KEY_SEQ"), 1);
         assertTrue(rs.next());
+        assertEquals(rs.getString("TABLE_NAME"), "Pk5");
+        assertEquals(rs.getString("COLUMN_NAME"), "Col3");
+        assertEquals(rs.getString("PK_NAME"), "NamedPk");
+        assertEquals(rs.getInt("KEY_SEQ"), 0);
+        assertFalse(rs.next());
+        rs.close();
+        
+        rs = meta.getPrimaryKeys(null, null, "Pk6");
+        assertTrue(rs.next());
+        assertEquals(rs.getString("TABLE_NAME"), "Pk6");
+        assertEquals(rs.getString("COLUMN_NAME"), "Col2");
+        assertEquals(rs.getString("PK_NAME"), "NamedPk");
+        assertEquals(rs.getInt("KEY_SEQ"), 1);
+        assertTrue(rs.next());
+        assertEquals(rs.getString("TABLE_NAME"), "Pk6");
         assertEquals(rs.getString("COLUMN_NAME"), "Col3");
         assertEquals(rs.getString("PK_NAME"), "NamedPk");
         assertEquals(rs.getInt("KEY_SEQ"), 0);

--- a/src/test/java/org/sqlite/DBMetaDataTest.java
+++ b/src/test/java/org/sqlite/DBMetaDataTest.java
@@ -539,7 +539,9 @@ public class DBMetaDataTest
         // extra spaces and mixed case are intentional, do not remove!
         stat.executeUpdate("create table pk4 (col1, col2, col3, col4, " +
                 "\r\nCONSTraint\r\nnamed  primary\r\n\t\t key   (col3, col2  ));");
-
+        // mixed-case table, column and primary key names
+        stat.executeUpdate("CREATE TABLE Pk5 (Col1, Col2, Col3, Col4, CONSTRAINT NamedPk PRIMARY KEY (Col3, Col2));");
+        
         rs = meta.getPrimaryKeys(null, null, "nopk");
         assertFalse(rs.next());
         rsmeta = rs.getMetaData();
@@ -556,6 +558,7 @@ public class DBMetaDataTest
         assertTrue(rs.next());
         assertEquals(rs.getString("PK_NAME"), null);
         assertEquals(rs.getString("COLUMN_NAME"), "col1");
+        assertEquals(rs.getInt("KEY_SEQ"), 0);
         assertFalse(rs.next());
         rs.close();
 
@@ -563,6 +566,7 @@ public class DBMetaDataTest
         assertTrue(rs.next());
         assertEquals(rs.getString("PK_NAME"), null);
         assertEquals(rs.getString("COLUMN_NAME"), "col2");
+        assertEquals(rs.getInt("KEY_SEQ"), 0);
         assertFalse(rs.next());
         rs.close();
 
@@ -586,6 +590,18 @@ public class DBMetaDataTest
         assertTrue(rs.next());
         assertEquals(rs.getString("COLUMN_NAME"), "col3");
         assertEquals(rs.getString("PK_NAME"), "named");
+        assertEquals(rs.getInt("KEY_SEQ"), 0);
+        assertFalse(rs.next());
+        rs.close();
+        
+        rs = meta.getPrimaryKeys(null, null, "Pk5");
+        assertTrue(rs.next());
+        assertEquals(rs.getString("COLUMN_NAME"), "Col2");
+        assertEquals(rs.getString("PK_NAME"), "NamedPk");
+        assertEquals(rs.getInt("KEY_SEQ"), 1);
+        assertTrue(rs.next());
+        assertEquals(rs.getString("COLUMN_NAME"), "Col3");
+        assertEquals(rs.getString("PK_NAME"), "NamedPk");
         assertEquals(rs.getInt("KEY_SEQ"), 0);
         assertFalse(rs.next());
         rs.close();


### PR DESCRIPTION
Removed unnecessary `toLowerCase()` when obtaining primary keys, and also added unit tests for mixed case primary key names.