### PR TITLE
Update README and build instructions to point to Github Issues instead of BitBucket Issues - fixes #242

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ is our utility to create personalized genome browsers.
 Public Discussion Forum
 =======================
 *  [Xerial Public Discussion Group](http://groups.google.com/group/xerial?hl=en)
-*  Post bug reports or feqture requests to [Issue Tracker](https://bitbucket.org/xerial/sqlite-jdbc/issues)
+*  Post bug reports or feqture requests to [Issue Tracker](https://github.com/xerial/sqlite-jdbc/issues)
 
 
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.xerial/sqlite-jdbc/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.xerial/sqlite-jdbc/)

--- a/README_BUILD.md
+++ b/README_BUILD.md
@@ -21,17 +21,17 @@ Build
 
 How to submit a patch
 =====================
-Bitbucket Pull Request
+GitHub Pull Request
 ----------------------
-1. Fork this project on bitbucket
+1. Fork this project on GitHub
 2. (make some change)
-3. `hg commit -m 'what changes are made to the source'`
-4. `hg push`
+3. `git commit -m 'what changes are made to the source'`
+4. `git push`
 5. Create a pull request
 
 Patch file
 ----------
-1. Create a new issue on <https://bitbucket.org/xerial/sqlite-jdbc/issues>
+1. Create a new issue on <https://github.com/xerial/sqlite-jdbc/issues>
 2. Attach a patch file to issue
 
 


### PR DESCRIPTION
Update README and build instructions to point to Github Issues instead of BitBucket Issues - fixes #242