### PR TITLE
Fix for class gc memory leak

### DIFF
--- a/src/main/java/org/sqlite/SQLiteJDBCLoader.java
+++ b/src/main/java/org/sqlite/SQLiteJDBCLoader.java
@@ -194,8 +194,8 @@ public class SQLiteJDBCLoader {
         String extractedLibFileName = String.format("sqlite-%s-%s-%s", getVersion(), uuid, libraryFileName);
         String extractedLckFileName = extractedLibFileName + ".lck";
 
-        File extractedLckFile = new File(targetFolder, extractedLckFileName);
         File extractedLibFile = new File(targetFolder, extractedLibFileName);
+        File extractedLckFile = new File(targetFolder, extractedLckFileName);
 
         try {
             // Extract a native library file into the target directory
@@ -213,6 +213,8 @@ public class SQLiteJDBCLoader {
             }
             finally {
                 // Delete the extracted lib file on JVM exit.
+                extractedLibFile.deleteOnExit();
+                extractedLckFile.deleteOnExit();
 
 
                 if(writer != null) {
@@ -251,10 +253,8 @@ public class SQLiteJDBCLoader {
         catch(IOException e) {
             System.err.println(e.getMessage());
             return false;
-        } finally {
-            extractedLibFile.delete();
-            extractedLckFile.delete();
         }
+
     }
 
     /**

--- a/src/main/java/org/sqlite/SQLiteJDBCLoader.java
+++ b/src/main/java/org/sqlite/SQLiteJDBCLoader.java
@@ -194,8 +194,8 @@ public class SQLiteJDBCLoader {
         String extractedLibFileName = String.format("sqlite-%s-%s-%s", getVersion(), uuid, libraryFileName);
         String extractedLckFileName = extractedLibFileName + ".lck";
 
-        File extractedLibFile = new File(targetFolder, extractedLibFileName);
         File extractedLckFile = new File(targetFolder, extractedLckFileName);
+        File extractedLibFile = new File(targetFolder, extractedLibFileName);
 
         try {
             // Extract a native library file into the target directory
@@ -213,8 +213,6 @@ public class SQLiteJDBCLoader {
             }
             finally {
                 // Delete the extracted lib file on JVM exit.
-                extractedLibFile.deleteOnExit();
-                extractedLckFile.deleteOnExit();
 
 
                 if(writer != null) {
@@ -253,8 +251,10 @@ public class SQLiteJDBCLoader {
         catch(IOException e) {
             System.err.println(e.getMessage());
             return false;
+        } finally {
+            extractedLibFile.delete();
+            extractedLckFile.delete();
         }
-
     }
 
     /**

--- a/src/main/java/org/sqlite/core/NativeDB.c
+++ b/src/main/java/org/sqlite/core/NativeDB.c
@@ -395,25 +395,44 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
 
     dbclass = (*env)->FindClass(env, "org/sqlite/core/NativeDB");
     if (!dbclass) return JNI_ERR;
-    dbclass = (*env)->NewGlobalRef(env, dbclass);
+    dbclass = (*env)->NewWeakGlobalRef(env, dbclass);
 
     fclass = (*env)->FindClass(env, "org/sqlite/Function");
     if (!fclass) return JNI_ERR;
-    fclass = (*env)->NewGlobalRef(env, fclass);
+    fclass = (*env)->NewWeakGlobalRef(env, fclass);
 
     aclass = (*env)->FindClass(env, "org/sqlite/Function$Aggregate");
     if (!aclass) return JNI_ERR;
-    aclass = (*env)->NewGlobalRef(env, aclass);
+    aclass = (*env)->NewWeakGlobalRef(env, aclass);
 
     pclass = (*env)->FindClass(env, "org/sqlite/core/DB$ProgressObserver");
     if(!pclass) return JNI_ERR;
-    pclass = (*env)->NewGlobalRef(env, pclass);
+    pclass = (*env)->NewWeakGlobalRef(env, pclass);
 
     phandleclass = (*env)->FindClass(env, "org/sqlite/ProgressHandler");
     if(!phandleclass) return JNI_ERR;
-    phandleclass = (*env)->NewGlobalRef(env, phandleclass);
+    phandleclass = (*env)->NewWeakGlobalRef(env, phandleclass);
 
     return JNI_VERSION_1_2;
+}
+
+// FINALIZATION
+
+JNIEXPORT void JNICALL JNI_OnUnload(JavaVM *vm, void *reserved) {
+    JNIEnv* env = 0;
+
+    if (JNI_OK != (*vm)->GetEnv(vm, (void **)&env, JNI_VERSION_1_2))
+        return;
+
+    if (dbclass) (*env)->DeleteWeakGlobalRef(env, dbclass);
+
+    if (fclass) (*env)->DeleteWeakGlobalRef(env, fclass);
+
+    if (aclass) (*env)->DeleteWeakGlobalRef(env, aclass);
+
+    if (pclass) (*env)->DeleteWeakGlobalRef(env, pclass);
+
+    if (phandleclass) (*env)->DeleteWeakGlobalRef(env, phandleclass);
 }
 
 


### PR DESCRIPTION
see issue #267 ; I found a more elegant, less intrusive solution.
I change the global refs to weak global refs. Since these references are
all to class objects, they will be referenced by the classloader
and not go away too early. But they won't keep the classes from becoming unreachable.
I verified, that this solves the problem
with this test:
[test.txt](https://github.com/xerial/sqlite-jdbc/files/1289555/test.txt)
Before the change, I get 10 instances of each sqlite related class in memory, after I get none.
The local tests during build (32bit Linux only) yield no errors.