### PR TITLE
Additional fix for issue #197

### DIFF
--- a/src/main/java/org/sqlite/SQLiteJDBCLoader.java
+++ b/src/main/java/org/sqlite/SQLiteJDBCLoader.java
@@ -200,10 +200,10 @@ public class SQLiteJDBCLoader {
         try {
             // Extract a native library file into the target directory
             InputStream reader = SQLiteJDBCLoader.class.getResourceAsStream(nativeLibraryFilePath);
-            FileOutputStream writer = new FileOutputStream(extractedLibFile);
             if(!extractedLckFile.exists()) {
                 new FileOutputStream(extractedLckFile).close();
             }
+            FileOutputStream writer = new FileOutputStream(extractedLibFile);
             try {
                 byte[] buffer = new byte[8192];
                 int bytesRead = 0;


### PR DESCRIPTION
Additional fix for issue #197 ; lock file needs to created before lib file. Otherwise the cleanup might see lib file, but not lock file, delete the lib file, and then the check starting with
InputStream extractedLibIn = new FileInputStream(extractedLibFile);
might fail.