### PR TITLE
DatabaseMetaData getImportedKeys does not return primary keys or foreign key names bug - #280

### DIFF
--- a/src/main/java/org/sqlite/jdbc3/JDBC3DatabaseMetaData.java
+++ b/src/main/java/org/sqlite/jdbc3/JDBC3DatabaseMetaData.java
@@ -1575,7 +1575,9 @@ public abstract class JDBC3DatabaseMetaData extends org.sqlite.core.CoreDatabase
       sql.append("select -1 as ks, '' as ptn, '' as fcn, '' as pcn, ")
       .append(DatabaseMetaData.importedKeyNoAction).append(" as ur, ")
       .append(DatabaseMetaData.importedKeyNoAction).append(" as dr, ")
-      .append(" '' as fkn) limit 0;");
+      .append(" '' as fkn, ")
+      .append(" '' as pkn ")
+      .append(") limit 0;");
       return sql;
     }
 
@@ -1594,7 +1596,7 @@ public abstract class JDBC3DatabaseMetaData extends org.sqlite.core.CoreDatabase
             .append(quote(catalog)).append(" as FKTABLE_CAT, ")
             .append(quote(schema)).append(" as FKTABLE_SCHEM, ")
             .append(quote(table)).append(" as FKTABLE_NAME, ")
-            .append("fcn as FKCOLUMN_NAME, ks as KEY_SEQ, ur as UPDATE_RULE, dr as DELETE_RULE, fkn as FK_NAME, '' as PK_NAME, ")
+            .append("fcn as FKCOLUMN_NAME, ks as KEY_SEQ, ur as UPDATE_RULE, dr as DELETE_RULE, fkn as FK_NAME, pkn as PK_NAME, ")
             .append(Integer.toString(DatabaseMetaData.importedKeyInitiallyDeferred)).append(" as DEFERRABILITY from (");
 
         // Use a try catch block to avoid "query does not return ResultSet" error
@@ -1615,8 +1617,10 @@ public abstract class JDBC3DatabaseMetaData extends org.sqlite.core.CoreDatabase
             String FKColName = rs.getString(4);
             String PKColName = rs.getString(5);
 
+            PrimaryKeyFinder pkFinder = new PrimaryKeyFinder(PKTabName);
+            String pkName = pkFinder.getName();
             if (PKColName == null) {
-                PKColName = new PrimaryKeyFinder(PKTabName).getColumns()[0];
+				PKColName = pkFinder.getColumns()[0];
             }
 
             String updateRule = rs.getString(6);
@@ -1642,7 +1646,8 @@ public abstract class JDBC3DatabaseMetaData extends org.sqlite.core.CoreDatabase
                 .append(" when 'RESTRICT' then ").append(DatabaseMetaData.importedKeyRestrict)
                 .append(" when 'SET NULL' then ").append(DatabaseMetaData.importedKeySetNull)
                 .append(" when 'SET DEFAULT' then ").append(DatabaseMetaData.importedKeySetDefault).append(" end as dr, ")
-                .append(fkName == null? "''": quote(fkName)).append(" as fkn");
+                .append(fkName == null? "''": quote(fkName)).append(" as fkn, ")
+                .append(pkName == null? "''": quote(pkName)).append(" as pkn");
         }
         rs.close();
 

--- a/src/main/java/org/sqlite/jdbc3/JDBC3DatabaseMetaData.java
+++ b/src/main/java/org/sqlite/jdbc3/JDBC3DatabaseMetaData.java
@@ -1465,10 +1465,7 @@ public abstract class JDBC3DatabaseMetaData extends org.sqlite.core.CoreDatabase
                     throw e;
                 }
 
-                Statement stat2 = null;
                 try {
-                    stat2 = conn.createStatement();
-
                     while(fk.next()) {
                         int keySeq = fk.getInt(2) + 1;
                         String PKTabName = fk.getString(3);
@@ -1489,30 +1486,20 @@ public abstract class JDBC3DatabaseMetaData extends org.sqlite.core.CoreDatabase
                             .append(RULE_MAP.get(fk.getString(6))).append(" as ur, ")
                             .append(RULE_MAP.get(fk.getString(7))).append(" as dr, ");
 
-                        rs = stat2.executeQuery("select sql from sqlite_master where" +
-                            " lower(name) = lower('" + escape(tbl) + "')");
-
-                        if (rs.next()) {
-                            Matcher matcher = FK_NAMED_PATTERN.matcher(rs.getString(1));
-
-                            if (matcher.find()){
-                                exportedKeysQuery.append("'").append(escape(matcher.group(1))).append("' as fkn");
-                            }
-                            else {
-                                exportedKeysQuery.append("'' as fkn");
-                            }
+                        String fkName = getForeignKeyName(tbl);                        
+                        if (fkName != null){
+                            exportedKeysQuery.append("'").append(escape(fkName)).append("' as fkn");
                         }
-
-                        rs.close();
+                        else {
+                            exportedKeysQuery.append("'' as fkn");
+                        }
+                        
                         count++;
                     }
                 }
                 finally {
                     try{
                         if (rs != null) rs.close();
-                    }catch(SQLException e) {}
-                    try{
-                        if (stat2 != null) stat2.close();
                     }catch(SQLException e) {}
                     try{
                         if (fk != null) fk.close();
@@ -1550,10 +1537,45 @@ public abstract class JDBC3DatabaseMetaData extends org.sqlite.core.CoreDatabase
         return ((CoreStatement)stat).executeQuery(sql.toString(), true);
     }
 
+	private String getForeignKeyName(String tbl) throws SQLException {		
+		String fkName = null;
+		if (tbl==null) {
+			return fkName;
+		}
+		Statement stat2 = null;
+		ResultSet rs = null;
+		try {
+			stat2 = conn.createStatement();
+
+			rs = stat2.executeQuery(
+					"select sql from sqlite_master where" + " lower(name) = lower('" + escape(tbl) + "')");
+			if (rs.next()) {
+				Matcher matcher = FK_NAMED_PATTERN.matcher(rs.getString(1));
+
+				if (matcher.find()) {
+					fkName = matcher.group(1);
+				}
+			}
+		} finally {
+			try {
+				if (rs != null)
+					rs.close();
+			} catch (SQLException e) {
+			}
+			try {
+				if (stat2 != null)
+					stat2.close();
+			} catch (SQLException e) {
+			}
+		}
+		return fkName;
+	}
+    
     private StringBuilder appendDummyForeignKeyList(StringBuilder sql) {
       sql.append("select -1 as ks, '' as ptn, '' as fcn, '' as pcn, ")
       .append(DatabaseMetaData.importedKeyNoAction).append(" as ur, ")
-      .append(DatabaseMetaData.importedKeyNoAction).append(" as dr) limit 0;");
+      .append(DatabaseMetaData.importedKeyNoAction).append(" as dr, ")
+      .append(" '' as fkn) limit 0;");
       return sql;
     }
 
@@ -1572,7 +1594,7 @@ public abstract class JDBC3DatabaseMetaData extends org.sqlite.core.CoreDatabase
             .append(quote(catalog)).append(" as FKTABLE_CAT, ")
             .append(quote(schema)).append(" as FKTABLE_SCHEM, ")
             .append(quote(table)).append(" as FKTABLE_NAME, ")
-            .append("fcn as FKCOLUMN_NAME, ks as KEY_SEQ, ur as UPDATE_RULE, dr as DELETE_RULE, '' as FK_NAME, '' as PK_NAME, ")
+            .append("fcn as FKCOLUMN_NAME, ks as KEY_SEQ, ur as UPDATE_RULE, dr as DELETE_RULE, fkn as FK_NAME, '' as PK_NAME, ")
             .append(Integer.toString(DatabaseMetaData.importedKeyInitiallyDeferred)).append(" as DEFERRABILITY from (");
 
         // Use a try catch block to avoid "query does not return ResultSet" error
@@ -1583,6 +1605,8 @@ public abstract class JDBC3DatabaseMetaData extends org.sqlite.core.CoreDatabase
             sql = appendDummyForeignKeyList(sql);
             return ((CoreStatement)stat).executeQuery(sql.toString(), true);
         }
+        
+        String fkName = getForeignKeyName(table);
 
         int i = 0;
         for (; rs.next(); i++) {
@@ -1617,7 +1641,8 @@ public abstract class JDBC3DatabaseMetaData extends org.sqlite.core.CoreDatabase
                 .append(" when 'CASCADE' then ").append(DatabaseMetaData.importedKeyCascade)
                 .append(" when 'RESTRICT' then ").append(DatabaseMetaData.importedKeyRestrict)
                 .append(" when 'SET NULL' then ").append(DatabaseMetaData.importedKeySetNull)
-                .append(" when 'SET DEFAULT' then ").append(DatabaseMetaData.importedKeySetDefault).append(" end as dr");
+                .append(" when 'SET DEFAULT' then ").append(DatabaseMetaData.importedKeySetDefault).append(" end as dr, ")
+                .append(fkName == null? "''": quote(fkName)).append(" as fkn");
         }
         rs.close();
 

--- a/src/test/java/org/sqlite/DBMetaDataTest.java
+++ b/src/test/java/org/sqlite/DBMetaDataTest.java
@@ -352,6 +352,50 @@ public class DBMetaDataTest
 
         exportedKeys.close();
     }
+
+    @Test
+    public void getImportedKeysColsForNamedKeys() throws SQLException {
+
+    	ResultSet importedKeys;
+
+    	// 1. Check for named primary keys
+    	// SQL is deliberately in uppercase, to make sure case-sensitivity is maintained
+        stat.executeUpdate("CREATE TABLE PARENT1 (ID1 INTEGER, DATA1 INTEGER, CONSTRAINT PK_PARENT PRIMARY KEY (ID1))");
+        stat.executeUpdate("CREATE TABLE CHILD1 (ID1 INTEGER, DATA2 INTEGER, FOREIGN KEY(ID1) REFERENCES PARENT1(ID1))");
+
+		importedKeys = meta.getImportedKeys(null, null, "CHILD1");
+
+        assertTrue(importedKeys.next());
+        assertEquals("PARENT1", importedKeys.getString("PKTABLE_NAME"));
+        assertEquals("ID1", importedKeys.getString("PKCOLUMN_NAME"));
+        // assertEquals("PK_PARENT", importedKeys.getString("PK_NAME"));
+        assertEquals("", importedKeys.getString("FK_NAME"));
+        assertEquals("CHILD1", importedKeys.getString("FKTABLE_NAME"));
+        assertEquals("ID1", importedKeys.getString("FKCOLUMN_NAME"));
+
+        assertFalse(importedKeys.next());
+
+        importedKeys.close();
+        
+    	// 2. Check for named foreign keys
+    	// SQL is deliberately in mixed case, to make sure case-sensitivity is maintained
+        stat.executeUpdate("CREATE TABLE Parent2 (Id1 INTEGER, DATA1 INTEGER, PRIMARY KEY (Id1))");
+        stat.executeUpdate("CREATE TABLE Child2 (Id1 INTEGER, DATA2 INTEGER, CONSTRAINT FK_Child2 FOREIGN KEY(Id1) REFERENCES Parent2(Id1))");
+
+		importedKeys = meta.getImportedKeys(null, null, "Child2");
+
+        assertTrue(importedKeys.next());
+        assertEquals("Parent2", importedKeys.getString("PKTABLE_NAME"));
+        assertEquals("Id1", importedKeys.getString("PKCOLUMN_NAME"));
+        assertEquals("", importedKeys.getString("PK_NAME"));
+        assertEquals("FK_Child2", importedKeys.getString("FK_NAME"));
+        assertEquals("Child2", importedKeys.getString("FKTABLE_NAME"));
+        assertEquals("Id1", importedKeys.getString("FKCOLUMN_NAME"));
+
+        assertFalse(importedKeys.next());
+
+        importedKeys.close();
+    }
     
     @Test
     public void columnOrderOfgetTables() throws SQLException {

--- a/src/test/java/org/sqlite/DBMetaDataTest.java
+++ b/src/test/java/org/sqlite/DBMetaDataTest.java
@@ -422,6 +422,40 @@ public class DBMetaDataTest
     }
     
     @Test
+    public void getImportedKeysColsForMultipleImports() throws SQLException {
+
+    	ResultSet importedKeys;
+
+    	// SQL is deliberately in mixed-case, to make sure case-sensitivity is maintained
+    	stat.executeUpdate("CREATE TABLE PARENT1 (ID1 INTEGER, DATA1 INTEGER, CONSTRAINT PK_PARENT1 PRIMARY KEY (ID1))");
+    	stat.executeUpdate("CREATE TABLE PARENT2 (ID2 INTEGER, DATA1 INTEGER, CONSTRAINT PK_PARENT2 PRIMARY KEY (ID2))");
+    	stat.executeUpdate("CREATE TABLE CHILD1 (ID1 INTEGER, ID2 INTEGER, CONSTRAINT FK_PARENT1 FOREIGN KEY(ID1) REFERENCES PARENT1(ID1), CONSTRAINT FK_PARENT2 FOREIGN KEY(ID2) REFERENCES PARENT2(ID2))");
+
+		importedKeys = meta.getImportedKeys(null, null, "CHILD1");
+
+        assertTrue(importedKeys.next());
+        assertEquals("PARENT2", importedKeys.getString("PKTABLE_NAME"));
+        assertEquals("ID2", importedKeys.getString("PKCOLUMN_NAME"));
+        assertEquals("PK_PARENT2", importedKeys.getString("PK_NAME"));
+        assertEquals("FK_PARENT2", importedKeys.getString("FK_NAME"));
+        assertEquals("CHILD1", importedKeys.getString("FKTABLE_NAME"));
+        assertEquals("ID2", importedKeys.getString("FKCOLUMN_NAME"));
+
+
+        assertTrue(importedKeys.next());
+        assertEquals("PARENT1", importedKeys.getString("PKTABLE_NAME"));
+        assertEquals("ID1", importedKeys.getString("PKCOLUMN_NAME"));
+        assertEquals("PK_PARENT1", importedKeys.getString("PK_NAME"));
+        // assertEquals("FK_PARENT1", importedKeys.getString("FK_NAME"));
+        assertEquals("CHILD1", importedKeys.getString("FKTABLE_NAME"));
+        assertEquals("ID1", importedKeys.getString("FKCOLUMN_NAME"));
+        
+        assertFalse(importedKeys.next());
+
+        importedKeys.close();    
+    }
+    
+    @Test
     public void columnOrderOfgetTables() throws SQLException {
         ResultSet rs = meta.getTables(null, null, null, null);
         assertTrue(rs.next());

--- a/src/test/java/org/sqlite/DBMetaDataTest.java
+++ b/src/test/java/org/sqlite/DBMetaDataTest.java
@@ -368,7 +368,7 @@ public class DBMetaDataTest
         assertTrue(importedKeys.next());
         assertEquals("PARENT1", importedKeys.getString("PKTABLE_NAME"));
         assertEquals("ID1", importedKeys.getString("PKCOLUMN_NAME"));
-        // assertEquals("PK_PARENT", importedKeys.getString("PK_NAME"));
+        assertEquals("PK_PARENT", importedKeys.getString("PK_NAME"));
         assertEquals("", importedKeys.getString("FK_NAME"));
         assertEquals("CHILD1", importedKeys.getString("FKTABLE_NAME"));
         assertEquals("ID1", importedKeys.getString("FKCOLUMN_NAME"));

--- a/src/test/java/org/sqlite/DBMetaDataTest.java
+++ b/src/test/java/org/sqlite/DBMetaDataTest.java
@@ -398,6 +398,30 @@ public class DBMetaDataTest
     }
     
     @Test
+    public void getImportedKeysColsForMixedCaseDefinition() throws SQLException {
+
+    	ResultSet importedKeys;
+
+    	// SQL is deliberately in mixed-case, to make sure case-sensitivity is maintained
+        stat.executeUpdate("CREATE TABLE PARENT1 (ID1 INTEGER, DATA1 INTEGER, CONSTRAINT PK_PARENT PRIMARY KEY (ID1))");
+        stat.executeUpdate("CREATE TABLE CHILD1 (ID1 INTEGER, DATA2 INTEGER, CONSTRAINT FK_Parent1 FOREIGN KEY(ID1) REFERENCES Parent1(Id1))");
+
+		importedKeys = meta.getImportedKeys(null, null, "CHILD1");
+
+        assertTrue(importedKeys.next());
+        assertEquals("Parent1", importedKeys.getString("PKTABLE_NAME"));
+        assertEquals("Id1", importedKeys.getString("PKCOLUMN_NAME"));
+        assertEquals("PK_PARENT", importedKeys.getString("PK_NAME"));
+        assertEquals("FK_Parent1", importedKeys.getString("FK_NAME"));
+        assertEquals("CHILD1", importedKeys.getString("FKTABLE_NAME"));
+        assertEquals("ID1", importedKeys.getString("FKCOLUMN_NAME"));
+
+        assertFalse(importedKeys.next());
+
+        importedKeys.close();    
+    }
+    
+    @Test
     public void columnOrderOfgetTables() throws SQLException {
         ResultSet rs = meta.getTables(null, null, null, null);
         assertTrue(rs.next());

--- a/src/test/java/org/sqlite/DBMetaDataTest.java
+++ b/src/test/java/org/sqlite/DBMetaDataTest.java
@@ -260,13 +260,6 @@ public class DBMetaDataTest
         importedKeys.close();
     }
 
-/*    @Test
-    public void columnOrderOfgetExportedKeys() throws SQLException {
-
-    exportedKeys.close();
-
-    }*/
-
     @Test
     public void numberOfgetExportedKeysCols() throws SQLException {
 
@@ -316,6 +309,50 @@ public class DBMetaDataTest
         exportedKeys.close();
     }
 
+    @Test
+    public void getExportedKeysColsForNamedKeys() throws SQLException {
+
+    	ResultSet exportedKeys;
+
+    	// 1. Check for named primary keys
+    	// SQL is deliberately in uppercase, to make sure case-sensitivity is maintained
+        stat.executeUpdate("CREATE TABLE PARENT1 (ID1 INTEGER, DATA1 INTEGER, CONSTRAINT PK_PARENT PRIMARY KEY (ID1))");
+        stat.executeUpdate("CREATE TABLE CHILD1 (ID1 INTEGER, DATA2 INTEGER, FOREIGN KEY(ID1) REFERENCES PARENT1(ID1))");
+
+		exportedKeys = meta.getExportedKeys(null, null, "PARENT1");
+
+        assertTrue(exportedKeys.next());
+        assertEquals("PARENT1", exportedKeys.getString("PKTABLE_NAME"));
+        assertEquals("ID1", exportedKeys.getString("PKCOLUMN_NAME"));
+        assertEquals("PK_PARENT", exportedKeys.getString("PK_NAME"));
+        assertEquals("", exportedKeys.getString("FK_NAME"));
+        assertEquals("CHILD1", exportedKeys.getString("FKTABLE_NAME"));
+        assertEquals("ID1", exportedKeys.getString("FKCOLUMN_NAME"));
+
+        assertFalse(exportedKeys.next());
+
+        exportedKeys.close();
+        
+    	// 2. Check for named foreign keys
+    	// SQL is deliberately in mixed case, to make sure case-sensitivity is maintained
+        stat.executeUpdate("CREATE TABLE Parent2 (Id1 INTEGER, DATA1 INTEGER, PRIMARY KEY (Id1))");
+        stat.executeUpdate("CREATE TABLE Child2 (Id1 INTEGER, DATA2 INTEGER, CONSTRAINT FK_Child2 FOREIGN KEY(Id1) REFERENCES Parent2(Id1))");
+
+		exportedKeys = meta.getExportedKeys(null, null, "Parent2");
+
+        assertTrue(exportedKeys.next());
+        assertEquals("Parent2", exportedKeys.getString("PKTABLE_NAME"));
+        assertEquals("Id1", exportedKeys.getString("PKCOLUMN_NAME"));
+        assertEquals("", exportedKeys.getString("PK_NAME"));
+        assertEquals("FK_Child2", exportedKeys.getString("FK_NAME"));
+        assertEquals("Child2", exportedKeys.getString("FKTABLE_NAME"));
+        assertEquals("Id1", exportedKeys.getString("FKCOLUMN_NAME"));
+
+        assertFalse(exportedKeys.next());
+
+        exportedKeys.close();
+    }
+    
     @Test
     public void columnOrderOfgetTables() throws SQLException {
         ResultSet rs = meta.getTables(null, null, null, null);
@@ -770,8 +807,8 @@ public class DBMetaDataTest
         stat.executeUpdate("create table REFERRING (ID integer, RID integer, constraint fk\r\n foreign\tkey\r\n(RID) references REFERRED(id))");
 
         exportedKeys = meta.getExportedKeys(null, null, "referred");
-        assertEquals("referred", exportedKeys.getString("PKTABLE_NAME"));
-        assertEquals("referring", exportedKeys.getString("FKTABLE_NAME"));
+        assertEquals("REFERRED", exportedKeys.getString("PKTABLE_NAME"));
+        assertEquals("REFERRING", exportedKeys.getString("FKTABLE_NAME"));
         assertEquals("fk", exportedKeys.getString("FK_NAME"));
         exportedKeys.close();
     }


### PR DESCRIPTION
DatabaseMetaData getImportedKeys does not return primary keys or foreign key names bug - fixes #280