### PR TITLE
change compiler source version to 1.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.1</version>
         <configuration>
-          <source>1.5</source>
+          <source>1.6</source>
           <target>1.6</target>
         </configuration>
       </plugin>


### PR DESCRIPTION
since SQLFeatureNotSupportedException is documented to only be available since 1.6
https://docs.oracle.com/javase/7/docs/api/java/sql/SQLFeatureNotSupportedException.html