### PR TITLE
Fix prepared statement parameter handling

### DIFF
--- a/src/main/java/org/sqlite/core/CorePreparedStatement.java
+++ b/src/main/java/org/sqlite/core/CorePreparedStatement.java
@@ -63,7 +63,7 @@ public abstract class CorePreparedStatement extends JDBC4Statement
      * @throws SQLException
      */
     protected void checkParameters() throws SQLException {
-        if ((batch == null && paramCount > 0) || (paramValid.cardinality() != paramCount))
+        if (paramValid.cardinality() != paramCount)
             throw new SQLException("Values not bound to statement");
     }
 

--- a/src/main/java/org/sqlite/jdbc3/JDBC3PreparedStatement.java
+++ b/src/main/java/org/sqlite/jdbc3/JDBC3PreparedStatement.java
@@ -107,6 +107,7 @@ public abstract class JDBC3PreparedStatement extends CorePreparedStatement {
      */
     public void addBatch() throws SQLException {
         checkOpen();
+        checkParameters();
         batchPos += paramCount;
         batchQueryCount++;
         if (batch == null) {

--- a/src/main/java/org/sqlite/jdbc3/JDBC3PreparedStatement.java
+++ b/src/main/java/org/sqlite/jdbc3/JDBC3PreparedStatement.java
@@ -36,7 +36,10 @@ public abstract class JDBC3PreparedStatement extends CorePreparedStatement {
     public void clearParameters() throws SQLException {
         checkOpen();
         db.clear_bindings(pointer);
-        batch = null;
+        paramValid.clear();
+        if (batch != null)
+            for (int i = batchPos; i < batchPos + paramCount; i++)
+                batch[i] = null;
     }
 
     /**
@@ -108,6 +111,7 @@ public abstract class JDBC3PreparedStatement extends CorePreparedStatement {
         batchQueryCount++;
         if (batch == null) {
             batch = new Object[paramCount];
+            paramValid.clear();
         }
         if (batchPos + paramCount > batch.length) {
             Object[] nb = new Object[batch.length * 2];

--- a/src/test/java/org/sqlite/PrepStmtTest.java
+++ b/src/test/java/org/sqlite/PrepStmtTest.java
@@ -480,7 +480,7 @@ public class PrepStmtTest
         assertEquals(meta.getColumnType(2), Types.INTEGER);
         assertEquals(meta.getColumnType(3), Types.INTEGER);*/
 
-        prep.setInt(1, 2);prep.setInt(2, 3);prep.setInt(1, -1);
+        prep.setInt(1, 2);prep.setInt(2, 3);prep.setInt(3, -1);
         meta = prep.executeQuery().getMetaData();
         assertEquals(meta.getColumnCount(), 3);
         prep.close();

--- a/src/test/java/org/sqlite/PrepStmtTest.java
+++ b/src/test/java/org/sqlite/PrepStmtTest.java
@@ -626,19 +626,11 @@ public class PrepStmtTest
         stat.executeUpdate("create table test (c1, c2);");
         PreparedStatement prep = conn.prepareStatement("insert into test values (?,?);");
         prep.setInt(1, 1);
-        prep.addBatch(); // <-- TODO: this should throw since we have a command with invalid params set
 
-        // we clear the params for the current statement which will reset validation
-        // the old statement becomes immutable once it's added via addBatch()
-        // and TODO: currently there is no validation when you add a statement to a batch
-
-        // if you delay the throw till the batch is executed you will need to keep increasing the BitSet
-        // which will blow it up for big batches and it's really unnecessary since you should fail as early as possible
-        prep.clearParameters();
-        prep.setInt(1, 3);
-        prep.setInt(2, 4);
+        // addBatch should throw since we added a command with invalid params set
+        // which becomes immutable once added to the batch so it makes sense to verify
+        // at the point when you add a command instead of delaying till batch execution
         prep.addBatch();
-        assertArrayEq(prep.executeBatch(), new int[] { 1, 1 });
     }
 
     @Test(expected = SQLException.class)

--- a/src/test/java/org/sqlite/PrepStmtTest.java
+++ b/src/test/java/org/sqlite/PrepStmtTest.java
@@ -608,6 +608,18 @@ public class PrepStmtTest
     }
 
     @Test(expected = SQLException.class)
+    public void preparedStatementShouldThrowIfNotAllParamsSet() throws SQLException {
+        PreparedStatement prep = conn.prepareStatement("select ? as col1, ? as col2, ? as col3;");
+        ResultSetMetaData meta = prep.getMetaData();
+        assertEquals(meta.getColumnCount(), 3);
+
+        // we only set one 1 param of the expected 3 params
+        prep.setInt(1, 2);
+        prep.executeQuery();
+        prep.close();
+    }
+
+    @Test(expected = SQLException.class)
     public void noSuchTable() throws SQLException {
         PreparedStatement prep = conn.prepareStatement("select * from doesnotexist;");
         prep.executeQuery();


### PR DESCRIPTION
please have a look at the commit messages for explanation
the current implementation does not verify that all parameters for the prepared
statement are set

I also front loaded the check into addBatch since once a statement/command is added it becomes immutable so therefore it doesn't make any sense to wait till execution for that check.

this allows to keep the memory of the bitset constant == paramCount since we only need to validate
the current statement/command since previous statements/commands are guaranteed ot be valid