### PR TITLE
Allocate batch array to deal with multiple queries in a single prepared statement.

### DIFF
--- a/src/main/java/org/sqlite/core/CorePreparedStatement.java
+++ b/src/main/java/org/sqlite/core/CorePreparedStatement.java
@@ -116,7 +116,7 @@ public abstract class CorePreparedStatement extends JDBC4Statement
     protected void batch(int pos, Object value) throws SQLException {
         checkOpen();
         if (batch == null) {
-            batch = new Object[paramCount];
+            batch = new Object[paramCount * batchQueryCount];
         }
         batch[batchPos + pos - 1] = value;
     }


### PR DESCRIPTION
Took a stab in the dark at a fix for #277 - this attempts to correctly deal with the issue where multiple queries are used in a single prepared statement, and the `batch` array is not allocated to handle the parameters, resulting in the `ArrayIndexOutofBoundsException`.