### PR TITLE
Skip synchronized block in close() if ResultSet is already closed

### DIFF
--- a/src/main/java/org/sqlite/core/CoreResultSet.java
+++ b/src/main/java/org/sqlite/core/CoreResultSet.java
@@ -120,19 +120,18 @@ public abstract class CoreResultSet implements Codes
         cols = null;
         colsMeta = null;
         meta = null;
-        open = false;
         limitRows = 0;
         row = 0;
         lastCol = -1;
         columnNameToIndex = null;
 
+        if (!open) {
+            return;
+        }
+
         DB db = stmt.getDatbase();
         synchronized (db) {
-            if (stmt == null) {
-                return;
-            }
-
-            if (stmt != null && stmt.pointer != 0) {
+            if (stmt.pointer != 0) {
                 db.reset(stmt.pointer);
 
                 if (closeStmt) {
@@ -141,6 +140,8 @@ public abstract class CoreResultSet implements Codes
                 }
             }
         }
+
+        open = false;
     }
 
     protected Integer findColumnIndexInCache(String col) {

--- a/src/test/java/org/sqlite/ResultSetTest.java
+++ b/src/test/java/org/sqlite/ResultSetTest.java
@@ -140,4 +140,18 @@ public class ResultSetTest {
         resultSet.findColumn("test.id");
     }
 
+    @Test
+    public void testCloseStatement()
+        throws SQLException {
+        ResultSet resultSet = stat.executeQuery("select test.id from test");
+
+        stat.close();
+
+        assertTrue(stat.isClosed());
+        assertTrue(resultSet.isClosed());
+
+        resultSet.close();
+
+        assertTrue(resultSet.isClosed());
+    }
 }


### PR DESCRIPTION
Fixes #349

From profiling our app in production we noticed that our finalizer thread was periodically waiting on the synchronized lock on the DB (introduced in #215).  By the time our ResultSet hits the finalizer queue the ResultSet has already been closed, so there's no need to acquire the lock to reset the statement pointer.  As part of this I've removed what I believe to be dead code around checking for the nullability of the stmt member on the ResultSet.