### PR TITLE
Fix spelling of TransactionMode.DEFERRED (#316)

### DIFF
--- a/src/main/java/org/sqlite/SQLiteConfig.java
+++ b/src/main/java/org/sqlite/SQLiteConfig.java
@@ -777,13 +777,20 @@ public class SQLiteConfig
     }
 
     public static enum TransactionMode implements PragmaValue {
-        DEFFERED, IMMEDIATE, EXCLUSIVE;
+        /**
+         * @deprecated Use {@code DEFERRED} instead.
+         */
+        @Deprecated DEFFERED,
+        DEFERRED, IMMEDIATE, EXCLUSIVE;
 
         public String getValue() {
             return name();
         }
 
         public static TransactionMode getMode(String mode) {
+            if ("DEFFERED".equalsIgnoreCase(mode)) {
+                return DEFERRED;
+            }
             return TransactionMode.valueOf(mode.toUpperCase());
         }
     }
@@ -799,7 +806,7 @@ public class SQLiteConfig
 
     /**
      * Sets the mode that will be used to start transactions.
-     * @param transactionMode One of DEFFERED, IMMEDIATE or EXCLUSIVE.
+     * @param transactionMode One of DEFERRED, IMMEDIATE or EXCLUSIVE.
      * @see <a href="http://www.sqlite.org/lang_transaction.html">http://www.sqlite.org/lang_transaction.html</a>
      */
     public void setTransactionMode(String transactionMode) {

--- a/src/main/java/org/sqlite/SQLiteConnectionConfig.java
+++ b/src/main/java/org/sqlite/SQLiteConnectionConfig.java
@@ -10,7 +10,7 @@ import java.util.Properties;
 import static org.sqlite.SQLiteConfig.DEFAULT_DATE_STRING_FORMAT;
 
 /**
- * Connection local cofigurations
+ * Connection local configurations
  */
 public class SQLiteConnectionConfig implements Cloneable
 {
@@ -20,7 +20,7 @@ public class SQLiteConnectionConfig implements Cloneable
     private FastDateFormat dateFormat = FastDateFormat.getInstance(dateStringFormat);
 
     private int transactionIsolation = Connection.TRANSACTION_SERIALIZABLE;
-    private SQLiteConfig.TransactionMode transactionMode = SQLiteConfig.TransactionMode.DEFFERED;
+    private SQLiteConfig.TransactionMode transactionMode = SQLiteConfig.TransactionMode.DEFERRED;
     private boolean autoCommit = true;
 
     public static SQLiteConnectionConfig fromPragmaTable(Properties pragmaTable) {
@@ -30,7 +30,7 @@ public class SQLiteConnectionConfig implements Cloneable
                 pragmaTable.getProperty(SQLiteConfig.Pragma.DATE_STRING_FORMAT.pragmaName, DEFAULT_DATE_STRING_FORMAT),
                 Connection.TRANSACTION_SERIALIZABLE,
                 SQLiteConfig.TransactionMode.getMode(
-                        pragmaTable.getProperty(SQLiteConfig.Pragma.TRANSACTION_MODE.pragmaName, SQLiteConfig.TransactionMode.DEFFERED.name())),
+                        pragmaTable.getProperty(SQLiteConfig.Pragma.TRANSACTION_MODE.pragmaName, SQLiteConfig.TransactionMode.DEFERRED.name())),
                 true);
     }
 
@@ -128,8 +128,12 @@ public class SQLiteConnectionConfig implements Cloneable
         return transactionMode;
     }
 
+    @SuppressWarnings("deprecation")
     public void setTransactionMode(SQLiteConfig.TransactionMode transactionMode)
     {
+        if (transactionMode == SQLiteConfig.TransactionMode.DEFFERED) {
+            transactionMode = SQLiteConfig.TransactionMode.DEFERRED;
+        }
         this.transactionMode = transactionMode;
     }
 
@@ -139,7 +143,7 @@ public class SQLiteConnectionConfig implements Cloneable
 
 
     static {
-        beginCommandMap.put(SQLiteConfig.TransactionMode.DEFFERED, "begin;");
+        beginCommandMap.put(SQLiteConfig.TransactionMode.DEFERRED, "begin;");
         beginCommandMap.put(SQLiteConfig.TransactionMode.IMMEDIATE, "begin immediate;");
         beginCommandMap.put(SQLiteConfig.TransactionMode.EXCLUSIVE, "begin exclusive;");
     }

--- a/src/main/java/org/sqlite/SQLiteDataSource.java
+++ b/src/main/java/org/sqlite/SQLiteDataSource.java
@@ -372,7 +372,7 @@ public class SQLiteDataSource implements DataSource
 
     /**
      * Sets the mode that will be used to start transactions for this database.
-     * @param transactionMode One of DEFFERED, IMMEDIATE or EXCLUSIVE.
+     * @param transactionMode One of DEFERRED, IMMEDIATE or EXCLUSIVE.
      * @see <a href="http://www.sqlite.org/lang_transaction.html">http://www.sqlite.org/lang_transaction.html</a>
      */
     public void setTransactionMode(String transactionMode) {

--- a/src/test/java/org/sqlite/TransactionTest.java
+++ b/src/test/java/org/sqlite/TransactionTest.java
@@ -341,15 +341,26 @@ public class TransactionTest
         SQLiteDataSource ds = new SQLiteDataSource();
         ds.setUrl("jdbc:sqlite:" + tmpFile.getAbsolutePath());
 
-        // deffered
+        // deferred
         SQLiteConnection con = (SQLiteConnection)ds.getConnection();
-        assertEquals(TransactionMode.DEFFERED, con.getConnectionConfig().getTransactionMode());
+        assertEquals(TransactionMode.DEFERRED, con.getConnectionConfig().getTransactionMode());
         assertEquals("begin;", con.getConnectionConfig().transactionPrefix());
         runUpdates(con, "tbl1");
         
-        ds.setTransactionMode(TransactionMode.DEFFERED.name());
+        ds.setTransactionMode(TransactionMode.DEFERRED.name());
         con = (SQLiteConnection)ds.getConnection();
-        assertEquals(TransactionMode.DEFFERED, con.getConnectionConfig().getTransactionMode());
+        assertEquals(TransactionMode.DEFERRED, con.getConnectionConfig().getTransactionMode());
+        assertEquals("begin;", con.getConnectionConfig().transactionPrefix());
+
+        // Misspelled deferred should be accepted for backwards compatibility
+        ds.setTransactionMode("DEFFERED");
+        con = (SQLiteConnection)ds.getConnection();
+        assertEquals(TransactionMode.DEFERRED, con.getConnectionConfig().getTransactionMode());
+        assertEquals("begin;", con.getConnectionConfig().transactionPrefix());
+
+        con = (SQLiteConnection)ds.getConnection();
+        con.getConnectionConfig().setTransactionMode(TransactionMode.valueOf("DEFFERED"));
+        assertEquals(TransactionMode.DEFERRED, con.getConnectionConfig().getTransactionMode());
         assertEquals("begin;", con.getConnectionConfig().transactionPrefix());
 
         // immediate


### PR DESCRIPTION
The misspelled DEFFERED is still accepted for backwards compatibility.

Fixes #316