### PR TITLE
Fix some tests

### DIFF
--- a/src/test/java/org/sqlite/BusyHandlerTest.java
+++ b/src/test/java/org/sqlite/BusyHandlerTest.java
@@ -8,6 +8,8 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.concurrent.CountDownLatch;
+
 import static org.junit.Assert.assertEquals;
 
 import static org.junit.Assert.fail;
@@ -31,45 +33,43 @@ public class BusyHandlerTest {
     public class BusyWork extends Thread {
         private final Connection conn;
         private final Statement stat;
+        private final CountDownLatch lockedLatch = new CountDownLatch(1);
+        private final CountDownLatch completeLatch = new CountDownLatch(1);
 
         public BusyWork() throws Exception {
             conn = DriverManager.getConnection("jdbc:sqlite:target/test.db");
+            Function.create(conn, "wait_for_latch", new Function() {
+                @Override
+                protected void xFunc() throws SQLException {
+                    lockedLatch.countDown();
+                    try {
+                        completeLatch.await();
+                    } catch (InterruptedException e) {
+                        throw new SQLException("Interrupted");
+                    }
+                    result(100);
+                }
+            });
             stat = conn.createStatement();
             stat.setQueryTimeout(1);
         }
 
         @Override
         public void run(){
-
             try {
-                synchronized(this) {
-                    // Generate some work for the sqlite vm
-                    stat.executeUpdate("drop table if exists foo;");
-                    stat.executeUpdate("create table foo (id integer);");
-
-                    int i = 0;
-                    while (i<10000) {
-                        String stmt = "insert into foo (id) values (" + i + ")";
-                        stat.addBatch(stmt);
-                        i++;
-                    }
-                }
+                // Generate some work for the sqlite vm
+                stat.executeUpdate("drop table if exists foo;");
+                stat.executeUpdate("create table foo (id integer);");
+                stat.execute("insert into foo (id) values (wait_for_latch());");
             } catch (SQLException ex) {System.out.println("HERE"+ex.toString());}
-
-            try {
-                stat.executeBatch();
-            } catch (SQLException ex) {System.out.println("BLOB"+ex.toString());}
         }
     }
 
-    private void workWork() throws SQLException, InterruptedException {
-        // I let busyWork inject first so it can busy the db
-        Thread.sleep(1000);
-
+    private void workWork() throws SQLException {
         // Generate some work for the sqlite vm
         int i = 0;
         while (i<5) {
-            stat.executeQuery("insert into foo (id) values (" + i + ")");
+            stat.execute("insert into foo (id) values (" + i + ")");
             i++;
         }
     }
@@ -94,18 +94,18 @@ public class BusyHandlerTest {
         BusyWork busyWork = new BusyWork();
         busyWork.start();
 
-        // I let busyWork prepare a huge insert
-        Thread.sleep(1000);
+        // let busyWork block inside insert
+        busyWork.lockedLatch.await();
 
-        synchronized(busyWork){
-            try{
-                workWork();
-            } catch(SQLException ex) {
-                assertEquals(SQLiteErrorCode.SQLITE_BUSY.code, ex.getErrorCode());
-            }
+        try{
+            workWork();
+            fail("Should throw SQLITE_BUSY exception");
+        } catch(SQLException ex) {
+            assertEquals(SQLiteErrorCode.SQLITE_BUSY.code, ex.getErrorCode());
         }
 
-        busyWork.interrupt();
+        busyWork.completeLatch.countDown();
+        busyWork.join();
         assertEquals(3, calls[0]);
     }
 
@@ -128,51 +128,33 @@ public class BusyHandlerTest {
 
         BusyWork busyWork = new BusyWork();
         busyWork.start();
-        // I let busyWork prepare a huge insert
-        Thread.sleep(1000);
-        synchronized(busyWork){
-            try{
-                workWork();
-            } catch(SQLException ex) {
-                assertEquals(SQLiteErrorCode.SQLITE_BUSY.code, ex.getErrorCode());
-            }
+        // let busyWork block inside insert
+        busyWork.lockedLatch.await();
+        try{
+            workWork();
+            fail("Should throw SQLITE_BUSY exception");
+        } catch(SQLException ex) {
+            assertEquals(SQLiteErrorCode.SQLITE_BUSY.code, ex.getErrorCode());
         }
+        busyWork.completeLatch.countDown();
+        busyWork.join();
         assertEquals(3, calls[0]);
 
         int totalCalls = calls[0];
         BusyHandler.clearHandler(conn);
         busyWork = new BusyWork();
         busyWork.start();
-        // I let busyWork prepare a huge insert
-        Thread.sleep(1000);
-        synchronized(busyWork){
-            try{
-                workWork();
-            } catch(SQLException ex) {
-                assertEquals(SQLiteErrorCode.SQLITE_BUSY.code, ex.getErrorCode());
-            }
-        }
-
-        busyWork.interrupt();
-        assertEquals(totalCalls, calls[0]);
-    }
-
-    @Test
-    public void testInterrupt() throws Exception {
-
-        try {
-            BusyHandler.setHandler(conn, new BusyHandler() {
-                @Override
-                protected int callback(int nbPrevInvok) throws SQLException {
-                    return 1;
-                }
-            });
+        // let busyWork block inside insert
+        busyWork.lockedLatch.await();
+        try{
             workWork();
-        } catch (SQLException ex) {
-            // Expected error
-            return;
+            fail("Should throw SQLITE_BUSY exception");
+        } catch(SQLException ex) {
+            assertEquals(SQLiteErrorCode.SQLITE_BUSY.code, ex.getErrorCode());
         }
-        // Progress function throws, not reached
-        fail();
+
+        busyWork.completeLatch.countDown();
+        busyWork.join();
+        assertEquals(totalCalls, calls[0]);
     }
 }

--- a/src/test/java/org/sqlite/SQLiteJDBCLoaderTest.java
+++ b/src/test/java/org/sqlite/SQLiteJDBCLoaderTest.java
@@ -36,6 +36,7 @@ import java.sql.Statement;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -117,6 +118,7 @@ public class SQLiteJDBCLoaderTest
 
     @Test
     public void test() throws Throwable {
+        final AtomicInteger completedThreads = new AtomicInteger(0);
         ExecutorService pool = Executors.newFixedThreadPool(32);
         for (int i = 0; i < 32; i++) {
             final String connStr = "jdbc:sqlite:target/sample-" + i + ".db";
@@ -136,9 +138,12 @@ public class SQLiteJDBCLoaderTest
                         e.printStackTrace();
                         Assert.fail(e.getLocalizedMessage());
                     }
+                    completedThreads.incrementAndGet();
                 }
             });
         }
+        pool.shutdown();
         pool.awaitTermination(3, TimeUnit.SECONDS);
+        assertEquals(32, completedThreads.get());
     }
 }

--- a/src/test/java/org/sqlite/TransactionTest.java
+++ b/src/test/java/org/sqlite/TransactionTest.java
@@ -80,6 +80,7 @@ public class TransactionTest
         // Second transaction starts and tries to complete but fails because first is still running
         boolean gotException = false;
         try {
+            ((SQLiteConnection) conn2).setBusyTimeout(10);
             conn2.setAutoCommit(false);
             if (pstat2 != null) {
                 // The prepared case would fail regardless of whether this was "execute" or "executeUpdate"
@@ -308,6 +309,7 @@ public class TransactionTest
         ResultSet rs = stat1.executeQuery("select * from t;");
         assertTrue(rs.next());
 
+        ((SQLiteConnection) conn2).setBusyTimeout(10);
         stat2.executeUpdate("insert into t values (3);"); // can't be done
     }
 


### PR DESCRIPTION
* BusyHandlerTest should now be deterministic.
* Removed BusyHandlerTest.testInterrupt as it probably didn't test
  what it was supposed to. The other two tests should be enough.
  (The "expected" SQLException was a "query does not return ResultSet"
  error because of executeQuery for insert instead of execute.)
* More verification in SQLiteJDBCLoaderTest.
* Make tests faster (run all tests in less than 2s instead of 20s).