### PR TITLE
Support temporary databases with no file name

### DIFF
--- a/src/main/java/org/sqlite/JDBC.java
+++ b/src/main/java/org/sqlite/JDBC.java
@@ -96,8 +96,7 @@ public class JDBC implements Driver
      * @return The location to the database.
      */
     static String extractAddress(String url) {
-        // if no file name is given use a memory database
-        return PREFIX.equalsIgnoreCase(url) ? ":memory:" : url.substring(PREFIX.length());
+        return url.substring(PREFIX.length());
     }
 
     /**

--- a/src/main/java/org/sqlite/SQLiteConnection.java
+++ b/src/main/java/org/sqlite/SQLiteConnection.java
@@ -181,7 +181,7 @@ public abstract class SQLiteConnection
         SQLiteConfig config = new SQLiteConfig(newProps);
 
         // check the path to the file exists
-        if (!":memory:".equals(fileName) && !fileName.startsWith("file:") && !fileName.contains("mode=memory")) {
+        if (!fileName.isEmpty() && !":memory:".equals(fileName) && !fileName.startsWith("file:") && !fileName.contains("mode=memory")) {
             if (fileName.startsWith(RESOURCE_NAME_PREFIX)) {
                 String resourceName = fileName.substring(RESOURCE_NAME_PREFIX.length());
 


### PR DESCRIPTION
When no database is specified, SQLite is supposed to create a [temporary database](https://www.sqlite.org/inmemorydb.html#temp_db), i.e. residing in memory but able to be flushed to disk under
memory pressure.
Actually, the driver forces SQLite to open an in-memory database
instead. These databases cannot be flushed to disk and might come out of
memory.