### PR TITLE
Fix issue #382: Wrong error message when open fails

### DIFF
--- a/src/main/java/org/sqlite/core/NativeDB.c
+++ b/src/main/java/org/sqlite/core/NativeDB.c
@@ -522,16 +522,17 @@ JNIEXPORT void JNICALL Java_org_sqlite_core_NativeDB__1open_1utf8(
     ret = sqlite3_open_v2(file_bytes, &db, flags, NULL);
     freeUtf8Bytes(file_bytes);
 
+    sethandle(env, this, db);
     if (ret != SQLITE_OK) {
+        ret = sqlite3_extended_errcode(db);
         throwex_errorcode(env, this, ret);
+        sethandle(env, this, 0); // The handle is needed for throwex_errorcode
         sqlite3_close(db);
         return;
     }
 
     // Ignore failures, as we can tolerate regular result codes.
     (void) sqlite3_extended_result_codes(db, 1);
-
-    sethandle(env, this, db);
 }
 
 JNIEXPORT void JNICALL Java_org_sqlite_core_NativeDB__1close(

--- a/src/test/java/org/sqlite/ErrorMessageTest.java
+++ b/src/test/java/org/sqlite/ErrorMessageTest.java
@@ -112,6 +112,18 @@ public class ErrorMessageTest {
     }
 
     @Test
+    public void cantOpenDir() throws SQLException, IOException {
+        File dir = File.createTempFile("error-message-test-cant-open-dir", "");
+        assumeTrue(dir.delete());
+        assumeTrue(dir.mkdir());
+        dir.deleteOnExit();
+
+        thrown.expectMessage(JUnitMatchers.containsString("[SQLITE_CANTOPEN_ISDIR]"));
+        Connection conn = DriverManager.getConnection("jdbc:sqlite:" + dir.getAbsolutePath());
+        conn.close();
+    }
+
+    @Test
     public void shouldUsePlainErrorCodeAsVendorCodeAndExtendedAsResultCode() throws SQLException, IOException {
         File from = File.createTempFile("error-message-test-plain-1", ".sqlite");
         from.deleteOnExit();

--- a/src/test/java/org/sqlite/ErrorMessageTest.java
+++ b/src/test/java/org/sqlite/ErrorMessageTest.java
@@ -118,7 +118,9 @@ public class ErrorMessageTest {
         assumeTrue(dir.mkdir());
         dir.deleteOnExit();
 
-        thrown.expectMessage(JUnitMatchers.containsString("[SQLITE_CANTOPEN_ISDIR]"));
+        thrown.expectMessage(JUnitMatchers.either(
+            JUnitMatchers.containsString("[SQLITE_CANTOPEN]")).or(
+            JUnitMatchers.containsString("[SQLITE_CANTOPEN_ISDIR]")));
         Connection conn = DriverManager.getConnection("jdbc:sqlite:" + dir.getAbsolutePath());
         conn.close();
     }


### PR DESCRIPTION
Creating a pull request of the patch for #382 in the hope of increasing its priority.

The fix always sets the database handle immediately after opening the database and simply clears it just after the `throwex_errorcode` call on failures, avoiding the issue that the `errmsg` call triggered by `throwex_errorcode` requires a valid database handle to be set, which is not true for the call in `_open_utf8` without this change.

Additionally a test is added that verifies that the correct more specific SQLite error message is returned when opening the database fails.