### PR TITLE
Update build process for JDK 10 (javah removal)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,12 +36,13 @@ $(SQLITE_UNPACKED): $(SQLITE_ARCHIVE)
 
 $(TARGET)/common-lib/org/sqlite/%.class: src/main/java/org/sqlite/%.java
 	@mkdir -p $(@D)
-	$(JAVAC) -source 1.5 -target 1.5 -sourcepath $(SRC) -d $(TARGET)/common-lib $<
+	$(JAVAC) -source 1.6 -target 1.6 -sourcepath $(SRC) -d $(TARGET)/common-lib $<
 
 jni-header: $(TARGET)/common-lib/NativeDB.h
 
-$(TARGET)/common-lib/NativeDB.h: $(TARGET)/common-lib/org/sqlite/core/NativeDB.class
-	$(JAVAH) -classpath $(TARGET)/common-lib -jni -o $@ org.sqlite.core.NativeDB
+$(TARGET)/common-lib/NativeDB.h: src/main/java/org/sqlite/core/NativeDB.java
+	$(JAVAC) -d $(TARGET)/common-lib -sourcepath $(SRC) -h $(TARGET)/common-lib src/main/java/org/sqlite/core/NativeDB.java
+	mv target/common-lib/org_sqlite_core_NativeDB.h target/common-lib/NativeDB.h
 
 test:
 	mvn test
@@ -157,6 +158,7 @@ clean-native:
 
 clean-java:
 	rm -rf $(TARGET)/*classes
+	rm -rf $(TARGET)/common-lib/*
 	rm -rf $(TARGET)/sqlite-jdbc-*jar
 
 clean-tests:

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ $(TARGET)/common-lib/org/sqlite/%.class: src/main/java/org/sqlite/%.java
 jni-header: $(TARGET)/common-lib/NativeDB.h
 
 $(TARGET)/common-lib/NativeDB.h: src/main/java/org/sqlite/core/NativeDB.java
+	@mkdir -p $(TARGET)/common-lib
 	$(JAVAC) -d $(TARGET)/common-lib -sourcepath $(SRC) -h $(TARGET)/common-lib src/main/java/org/sqlite/core/NativeDB.java
 	mv target/common-lib/org_sqlite_core_NativeDB.h target/common-lib/NativeDB.h
 


### PR DESCRIPTION
javah has been superseded by the -h option added to javac in JDK 8.
The tool javah.exe was removed in Java 10.
(https://stackoverflow.com/questions/50352098/javah-missing-after-jdk-install)

Also clean output files generated by javac -h.

With this patch I was able to build with JDK 8 and JDK 11.

CI fails for JDK 7 — is it worth supporting that?