### PR TITLE
Add compile option 'JDBC_EXTENSIONS'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,10 @@ $(SQLITE_OUT)/sqlite3.o : $(SQLITE_UNPACKED)
 	    $(SQLITE_SOURCE)/sqlite3ext.h > $(SQLITE_OUT)/sqlite3ext.h
 # insert a code for loading extension functions
 	perl -p -e "s/^opendb_out:/  if(!db->mallocFailed && rc==SQLITE_OK){ rc = RegisterExtensionFunctions(db); }\nopendb_out:/;" \
-	    $(SQLITE_SOURCE)/sqlite3.c > $(SQLITE_OUT)/sqlite3.c
+	    $(SQLITE_SOURCE)/sqlite3.c > $(SQLITE_OUT)/sqlite3.c.tmp
+# register compile option 'JDBC_EXTENSIONS'
+	perl -p -e "s/#if SQLITE_LIKE_DOESNT_MATCH_BLOBS/  \"JDBC_EXTENSIONS\",\n#if SQLITE_LIKE_DOESNT_MATCH_BLOBS/;" \
+	    $(SQLITE_OUT)/sqlite3.c.tmp > $(SQLITE_OUT)/sqlite3.c
 	cat src/main/ext/*.c >> $(SQLITE_OUT)/sqlite3.c
 	$(CC) -o $@ -c $(CCFLAGS) \
 	    -DSQLITE_ENABLE_LOAD_EXTENSION=1 \

--- a/src/test/java/org/sqlite/ExtensionTest.java
+++ b/src/test/java/org/sqlite/ExtensionTest.java
@@ -1,6 +1,7 @@
 package org.sqlite;
 
 import org.junit.After;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -57,6 +58,21 @@ public class ExtensionTest {
 
     @Test
     public void extFunctions() throws Exception {
+        {
+            ResultSet rs = stat.executeQuery("pragma compile_options");
+            boolean hasJdbcExtensions = false;
+            while (rs.next()) {
+                String compileOption = rs.getString(1);
+                if (compileOption.equals("JDBC_EXTENSIONS")) {
+                    hasJdbcExtensions = true;
+                    break;
+                }
+            }
+            rs.close();
+            // SQLite has to be compiled with JDBC Extensions for this test to
+            // continue.
+            Assume.assumeTrue(hasJdbcExtensions);
+        }
         {
             ResultSet rs = stat.executeQuery("select cos(radians(45))");
             assertTrue(rs.next());


### PR DESCRIPTION
If SQLite has been augmented with JDBC extensions add a compile option
which can be queried from the 'compile_options' pragma.
This makes it possible to determine at runtime whether the client supports
customs functions or not.