### PR TITLE
Remove sparse index checks

### DIFF
--- a/src/main/java/org/sqlite/jdbc3/JDBC3PreparedStatement.java
+++ b/src/main/java/org/sqlite/jdbc3/JDBC3PreparedStatement.java
@@ -36,7 +36,6 @@ public abstract class JDBC3PreparedStatement extends CorePreparedStatement {
     public void clearParameters() throws SQLException {
         checkOpen();
         conn.getDatabase().clear_bindings(pointer);
-        paramValid.clear();
         if (batch != null)
             for (int i = batchPos; i < batchPos + paramCount; i++)
                 batch[i] = null;
@@ -49,7 +48,6 @@ public abstract class JDBC3PreparedStatement extends CorePreparedStatement {
         checkOpen();
         rs.close();
         conn.getDatabase().reset(pointer);
-        checkParameters();
 
         boolean success = false;
         try {
@@ -73,7 +71,6 @@ public abstract class JDBC3PreparedStatement extends CorePreparedStatement {
 
         rs.close();
         conn.getDatabase().reset(pointer);
-        checkParameters();
 
         boolean success = false;
         try {
@@ -97,7 +94,6 @@ public abstract class JDBC3PreparedStatement extends CorePreparedStatement {
 
         rs.close();
         conn.getDatabase().reset(pointer);
-        checkParameters();
 
         return conn.getDatabase().executeUpdate(this, batch);
     }
@@ -107,12 +103,10 @@ public abstract class JDBC3PreparedStatement extends CorePreparedStatement {
      */
     public void addBatch() throws SQLException {
         checkOpen();
-        checkParameters();
         batchPos += paramCount;
         batchQueryCount++;
         if (batch == null) {
             batch = new Object[paramCount];
-            paramValid.clear();
         }
         if (batchPos + paramCount > batch.length) {
             Object[] nb = new Object[batch.length * 2];

--- a/src/test/java/org/sqlite/PrepStmtTest.java
+++ b/src/test/java/org/sqlite/PrepStmtTest.java
@@ -578,6 +578,7 @@ public class PrepStmtTest
     public void clearParameters() throws SQLException {
         stat.executeUpdate("create table tbl (colid integer primary key AUTOINCREMENT, col varchar)");
         stat.executeUpdate("insert into tbl(col) values (\"foo\")");
+        stat.executeUpdate("insert into tbl(col) values (?)");
 
         PreparedStatement prep = conn.prepareStatement("select colid from tbl where col = ?");
 
@@ -591,36 +592,26 @@ public class PrepStmtTest
 
         rs.close();
 
-        try {
-            prep.execute();
-            fail("Returned result when values not bound to prepared statement");
-        } catch (Exception e) {
-            assertEquals("Values not bound to statement", e.getMessage());
-        }
+        // should not throw
+        prep.execute();
 
-        try {
-            rs = prep.executeQuery();
-            fail("Returned result when values not bound to prepared statement");
-        } catch (Exception e) {
-            assertEquals("Values not bound to statement", e.getMessage());
-        }
+        // should not throw
+        PreparedStatement nullPrep = conn.prepareStatement("select colid from tbl where col is null");
+        rs = nullPrep.executeQuery();
+        rs.next();
 
-        prep.close();
+        // gets the row with the NULL column
+        assertEquals(2, rs.getInt(1));
 
-        try {
-            prep = conn.prepareStatement("insert into tbl(col) values (?)");
-            prep.clearParameters();
-            prep.executeUpdate();
-            fail("Returned result when values not bound to prepared statement");
-        } catch (Exception e) {
-            assertEquals("Values not bound to statement", e.getMessage());
-        }
+        rs.close();
+        nullPrep.close();
     }
 
-    @Test(expected = SQLException.class)
-    public void preparedStatementShouldThrowIfNotAllParamsSet() throws SQLException {
+    public void preparedStatementShouldNotThrowIfNotAllParamsSet() throws SQLException {
         PreparedStatement prep = conn.prepareStatement("select ? as col1, ? as col2, ? as col3;");
         ResultSetMetaData meta = prep.getMetaData();
+
+        // leaves 0 and 1 unbound
         assertEquals(meta.getColumnCount(), 3);
 
         // we only set one 1 param of the expected 3 params
@@ -629,15 +620,13 @@ public class PrepStmtTest
         prep.close();
     }
 
-    @Test(expected = SQLException.class)
-    public void preparedStatementShouldThrowIfNotAllParamsSetBatch() throws SQLException {
+    public void preparedStatementShouldNotThrowIfNotAllParamsSetBatch() throws SQLException {
         stat.executeUpdate("create table test (c1, c2);");
         PreparedStatement prep = conn.prepareStatement("insert into test values (?,?);");
+
+        // leaves param 0 unbound
         prep.setInt(1, 1);
 
-        // addBatch should throw since we added a command with invalid params set
-        // which becomes immutable once added to the batch so it makes sense to verify
-        // at the point when you add a command instead of delaying till batch execution
         prep.addBatch();
     }
 


### PR DESCRIPTION
This fixes #393. This is correct/safe for a few reasons:

- Un-bound parameters are okay. sqlite interprets unbound parameters as `null` (near the bottom here: https://www.sqlite.org/c3ref/bind_blob.html).
- With this update, un-bound parameters in this library will be bound as null, but this is also okay because (see above) that's equivalent to binding null.
- This matches the implementations of other drivers:
-- requery/sqlite-android: https://github.com/requery/sqlite-android/blob/da119c1aa926975330ff727067fedc93e49da5f2/sqlite-android/src/main/java/io/requery/android/database/sqlite/SQLiteConnection.java#L1028
-- Android SQLite: https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/database/sqlite/SQLiteConnection.java#1088

Worst case, this defers to sqlite to error, and then an exception comes through that way.

FWIW, we've been using an internal build with this patch since I posted in #393 without issue.

Note: This contribution is made by Autodesk Inc. under the terms of the Apache 2.0 license.