### PR TITLE
Add Alpine support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ linux64: $(SQLITE_UNPACKED) jni-header
 	docker run $(DOCKER_RUN_OPTS) -ti -v $$PWD:/work xerial/centos5-linux-x86_64 bash -c 'make clean-native native OS_NAME=Linux OS_ARCH=x86_64'
 
 alpine-linux64: $(SQLITE_UNPACKED) jni-header
-	docker run $(DOCKER_RUN_OPTS) -ti -v $$PWD:/work xerial/alpine-linux-x86_64 bash -c 'make clean-native native OS_NAME=Linux OS_ARCH=x86_64'
+	docker run $(DOCKER_RUN_OPTS) -ti -v $$PWD:/work xerial/alpine-linux-x86_64 bash -c 'make clean-native native OS_NAME=Linux-Alpine OS_ARCH=x86_64'
 
 linux-arm: $(SQLITE_UNPACKED) jni-header
 	./docker/dockcross-armv5 -a $(DOCKER_RUN_OPTS) bash -c 'make clean-native native CROSS_PREFIX=/usr/xcc/armv5-unknown-linux-gnueabi/bin/armv5-unknown-linux-gnueabi- OS_NAME=Linux OS_ARCH=arm'

--- a/docker/Dockerfile.alpine-linux_x86_64
+++ b/docker/Dockerfile.alpine-linux_x86_64
@@ -1,4 +1,4 @@
-FROM alpine
+FROM alpine:3.11
 MAINTAINER Taro L. Saito <leo@xerial.org>
 
 RUN apk --update add bash gcc make perl libc-dev

--- a/src/main/java/org/sqlite/util/OSInfo.java
+++ b/src/main/java/org/sqlite/util/OSInfo.java
@@ -113,6 +113,33 @@ public class OSInfo
         return System.getProperty("java.runtime.name", "").toLowerCase().contains("android");
     }
 
+    public static boolean isAlpine() {
+        try {
+            Process p = Runtime.getRuntime().exec("cat /etc/os-release | grep ^ID");
+            p.waitFor();
+
+            InputStream in = p.getInputStream();
+            try {
+                int readLen = 0;
+                ByteArrayOutputStream b = new ByteArrayOutputStream();
+                byte[] buf = new byte[32];
+                while((readLen = in.read(buf, 0, buf.length)) >= 0) {
+                    b.write(buf, 0, readLen);
+                }
+                return b.toString().toLowerCase().contains("alpine");
+            }
+            finally {
+                if(in != null) {
+                    in.close();
+                }
+            }
+                
+        } catch (Throwable e) {
+            return false;
+        }
+        
+    }
+
     static String getHardwareName() {
         try {
             Process p = Runtime.getRuntime().exec("uname -m");
@@ -221,6 +248,9 @@ public class OSInfo
         }
         else if (osName.contains("Mac") || osName.contains("Darwin")) {
             return "Mac";
+        }
+        else if (isAlpine()) {
+            return "Linux-Alpine";
         }
         else if (osName.contains("Linux")) {
             return "Linux";


### PR DESCRIPTION
Please have a look at our extension that make the resulting jar files also work in an Alpine Linux container.

Changes:
- Changed to name of the compile SQLite binary when compiling for Alpine (as not to conflict with normal x86_64 linux)
- Added a small function in OSInfo.java that determines whether the code is running in an Alpine environment and uses the corresponding SQLite binary if this is the case.

 Looking forward to your comments!