### PR TITLE
Preserve extended result codes in SQLiteException

### DIFF
--- a/src/main/java/org/sqlite/core/DB.java
+++ b/src/main/java/org/sqlite/core/DB.java
@@ -846,8 +846,8 @@ public abstract class DB implements Codes
             }
         }
 
-        int statusCode = step(stmt.pointer) & 0xFF;
-        switch (statusCode) {
+        int statusCode = step(stmt.pointer);
+        switch (statusCode & 0xFF) {
         case SQLITE_DONE:
             reset(stmt.pointer);
             ensureAutoCommit(stmt.conn.getAutoCommit());

--- a/src/test/java/org/sqlite/PrepStmtTest.java
+++ b/src/test/java/org/sqlite/PrepStmtTest.java
@@ -679,6 +679,24 @@ public class PrepStmtTest
         }
     }
 
+    @Test
+    public void constraintExtendedResultCodeExecute() throws SQLException {
+        assertEquals(0, stat.executeUpdate("create table foo (id integer, CONSTRAINT U_ID UNIQUE (id));"));
+        assertEquals(1, stat.executeUpdate("insert into foo values(1);"));
+        // try to insert a row with duplicate id
+        try {
+            PreparedStatement statement = conn.prepareStatement("insert into foo values(?);");
+            statement.setInt(1, 1);
+            statement.execute();
+            fail("expected exception");
+        } catch (SQLException e) {
+            assertEquals(SQLiteErrorCode.SQLITE_CONSTRAINT.code, e.getErrorCode());
+
+            // Extended error code should be preserved in SQLiteException#resultCode
+            assertEquals(SQLiteErrorCode.SQLITE_CONSTRAINT_UNIQUE, ((SQLiteException) e).getResultCode());
+        }
+    }
+
     private void assertArrayEq(byte[] a, byte[] b) {
         assertNotNull(a);
         assertNotNull(b);


### PR DESCRIPTION
Prior to 37278d1, extended result codes were preserved when throwing a
SQLiteException. This restores that behavior.

Refs #343