### PR TITLE
Remove Override OBject.finalize in Statement and ResultSet

### DIFF
--- a/src/main/java/org/sqlite/core/CorePreparedStatement.java
+++ b/src/main/java/org/sqlite/core/CorePreparedStatement.java
@@ -52,14 +52,6 @@ public abstract class CorePreparedStatement extends JDBC4Statement
     }
 
     /**
-     * @see org.sqlite.core.CoreStatement#finalize()
-     */
-    @Override
-    protected void finalize() throws SQLException {
-        close();
-    }
-
-    /**
      * @see org.sqlite.jdbc3.JDBC3Statement#executeBatch()
      */
     @Override

--- a/src/main/java/org/sqlite/jdbc3/JDBC3ResultSet.java
+++ b/src/main/java/org/sqlite/jdbc3/JDBC3ResultSet.java
@@ -157,14 +157,6 @@ public abstract class JDBC3ResultSet extends CoreResultSet {
     }
 
     /**
-     * @see java.lang.Object#finalize()
-     */
-    @Override
-    protected void finalize() throws SQLException {
-        close();
-    }
-
-    /**
      * @see java.sql.ResultSet#getRow()
      */
     public int getRow() throws SQLException {

--- a/src/main/java/org/sqlite/jdbc3/JDBC3Statement.java
+++ b/src/main/java/org/sqlite/jdbc3/JDBC3Statement.java
@@ -28,13 +28,6 @@ public abstract class JDBC3Statement extends CoreStatement {
     }
 
     /**
-     * @see java.lang.Object#finalize()
-     */
-    protected void finalize() throws SQLException {
-        close();
-    }
-
-    /**
      * @see java.sql.Statement#execute(java.lang.String)
      */
     public boolean execute(String sql) throws SQLException {


### PR DESCRIPTION
This PR is to fix #217.  Overriding finalize() on these 3 classes actually causes memory leak since the finalize() method adds a reference to the JVM Finalizer and this prevents the objects from garbage collection until the System finalization is invoked by the JVM.  So it is actually counter productive of having these method overridden for attempting to clean up resources; and not to say that, it's an anti-pattern in Java of overriding finalize() for the exact reason it's stated.

Also, these classes already have the close() method implemented, so callers should call close() to release resource and that's how JDBC [Statement](https://docs.oracle.com/javase/8/docs/api/java/sql/Statement.html#close--) and [ResultSet](https://docs.oracle.com/javase/8/docs/api/java/sql/ResultSet.html#close--) interfaces are designed to operate.

I tested this fix in a heavy loaded env with 50 threads and each makes 10+ per second db calls.  Without this fix, the JVM (Xmx=16GB) ran out of memory and hang in a relatively short period of time (15 mins).  By using a Java profiler, I observed over a few GBs of the PreparedStatement and ResultSet objects held by the java.lang.ref.Finalizer and garbage collector could not reclaim these heap memory due to a reference to the Finalizer.  Once I applied this fix, the JVM ran just fine without the memory issue and GC successfully reclaimed the heap resources.
