### PR TITLE
adding timeout to OSInfo::isAlpine

### DIFF
--- a/src/main/java/org/sqlite/util/OSInfo.java
+++ b/src/main/java/org/sqlite/util/OSInfo.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Locale;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Provides OS name and architecture name.
@@ -116,7 +117,7 @@ public class OSInfo
     public static boolean isAlpine() {
         try {
             Process p = Runtime.getRuntime().exec("cat /etc/os-release | grep ^ID");
-            p.waitFor();
+            p.waitFor(300, TimeUnit.MILLISECONDS);
 
             InputStream in = p.getInputStream();
             try {


### PR DESCRIPTION
I am on Ubuntu 20, openJdk 14.0.2,
I am using sqlite from Apache Netbeans with Gradle 6.7


When debugging, isAlpine() kind of always blocks, not sure why. Sometimes it does not block.

When emitting "cat /etc/os-release | grep ^ID" to console in ubuntu, there is no problem, works as excepted.

When running, also sometimes blocks, sometimes runs.


I am wondering if it is a problem with openJdk.

Shortly before getConnection, I delete  the database file with File.deleteIfExists !?


ANYHOW: Having a timeout here is a small improvement. It adds stability.