### PR TITLE
fix aarch64 detection

### DIFF
--- a/src/main/java/org/sqlite/util/OSInfo.java
+++ b/src/main/java/org/sqlite/util/OSInfo.java
@@ -184,9 +184,9 @@ public class OSInfo
                 // Use armv5, soft-float ABI
                 return "arm";
             }
-            else if (armType.equals("aarch64")) {
+            else if (armType.startsWith("aarch64")) {
                 // Use arm64
-                return "arm64";
+                return "aarch64";
             }
 
             // Java 1.8 introduces a system property to determine armel or armhf


### PR DESCRIPTION
This code path probably never worked. `uname -m` returns a value terminated by a newline, so the comparison never worked. Even if it did, it would have returned `arm64`, which is not a valid folder name for the native library.

Why it may have worked on `aarch64` systems is that after that failed comparison, it would detect the JVM and find out it's `armv7`, which is compatible with `arm64`, so probably went unnoticed.