### PR TITLE
Don't use ByteBuffer decode() - slower

### DIFF
--- a/src/main/java/org/sqlite/core/NativeDB.java
+++ b/src/main/java/org/sqlite/core/NativeDB.java
@@ -504,7 +504,9 @@ public final class NativeDB extends DB
             return null;
         }
         try {
-            return Charset.forName("UTF-8").decode(buffer).toString();
+            byte[] buff = new byte[buffer.remaining()];
+            buffer.get(buff);
+            return new String(buff, Charset.forName("UTF-8"));
         }
         catch (UnsupportedCharsetException e) {
             throw new RuntimeException("UTF-8 is not supported", e);

--- a/src/main/java/org/sqlite/core/NativeDB.java
+++ b/src/main/java/org/sqlite/core/NativeDB.java
@@ -491,26 +491,16 @@ public final class NativeDB extends DB
         if (str == null) {
             return null;
         }
-        try {
-            return str.getBytes("UTF-8");
-        }
-        catch (UnsupportedEncodingException e) {
-            throw new RuntimeException("UTF-8 is not supported", e);
-        }
+        return str.getBytes(StandardCharsets.UTF_8);
     }
 
     static String utf8ByteBufferToString(ByteBuffer buffer) {
         if (buffer == null) {
             return null;
         }
-        try {
-            byte[] buff = new byte[buffer.remaining()];
-            buffer.get(buff);
-            return new String(buff, Charset.forName("UTF-8"));
-        }
-        catch (UnsupportedCharsetException e) {
-            throw new RuntimeException("UTF-8 is not supported", e);
-        }
+        byte[] buff = new byte[buffer.remaining()];
+        buffer.get(buff);
+        return new String(buff, StandardCharsets.UTF_8);
     }
 
     public native synchronized void register_progress_handler(int vmCalls, ProgressHandler progressHandler) throws SQLException;


### PR DESCRIPTION
Profiling this has revealed it's faster to just use the String decoding methods vs the ByteBuffer decoding methods.  This adds a copy back to the process of getting data out of SQLite but it removes the JNI allocation (my original issue).