### PR TITLE
Normalize source string when parsing

### DIFF
--- a/src/main/java/org/sqlite/date/FastDateParser.java
+++ b/src/main/java/org/sqlite/date/FastDateParser.java
@@ -288,15 +288,16 @@ public class FastDateParser implements DateParser, Serializable {
      * @see org.apache.commons.lang3.time.DateParser#parse(java.lang.String)
      */
     public Date parse(final String source) throws ParseException {
-        final Date date= parse(source, new ParsePosition(0));
+        String normalizedSource = source.length() == 19 ? (source + ".000") : source;
+        final Date date= parse(normalizedSource, new ParsePosition(0));
         if(date==null) {
             // Add a note re supported date range
             if (locale.equals(JAPANESE_IMPERIAL)) {
                 throw new ParseException(
                         "(The " +locale + " locale does not support dates before 1868 AD)\n" +
-                                "Unparseable date: \""+source+"\" does not match "+parsePattern.pattern(), 0);
+                                "Unparseable date: \""+normalizedSource+"\" does not match "+parsePattern.pattern(), 0);
             }
-            throw new ParseException("Unparseable date: \""+source+"\" does not match "+parsePattern.pattern(), 0);
+            throw new ParseException("Unparseable date: \""+normalizedSource+"\" does not match "+parsePattern.pattern(), 0);
         }
         return date;
     }

--- a/src/test/java/org/sqlite/StatementTest.java
+++ b/src/test/java/org/sqlite/StatementTest.java
@@ -421,6 +421,18 @@ public class StatementTest
         Date d = rs.getDate(1);
         assertEquals(day.getTime(), d.getTime());
     }
+    
+    @Test
+    public void defaultDateTimeTest() throws SQLException {
+        stat.executeUpdate("create table daywithdefaultdatetime (id integer, datetime datatime default current_timestamp)");
+        PreparedStatement prep = conn.prepareStatement("insert into daywithdefaultdatetime (id) values (1)");
+        prep.setInt(1, 1);
+        prep.executeUpdate();
+        ResultSet rs = stat.executeQuery("select * from day");
+        assertTrue(rs.next());
+        Date d = rs.getDate(2);
+        assertTrue(d != null);
+    }
 
     @Test
     public void maxRows() throws SQLException {


### PR DESCRIPTION
This pull request fixes the bug described by issue https://github.com/xerial/sqlite-jdbc/issues/88

This bug can be reproduced by using `ResultSet.getDate()` to parse a `DATETIME` created using `CURRENT_TIMESTAMP`

The exception thrown will look something like this:
`java.text.ParseException: Unparseable date: "2021-06-08 02:00:47" does not match (\p{Nd}++)\Q-\E(\p{Nd}++)\Q-\E(\p{Nd}++)\Q \E(\p{Nd}++)\Q:\E(\p{Nd}++)\Q:\E(\p{Nd}++)\Q.\E(\p{Nd}++)`

The regex used to parse dates does not account for the fact that new dates created by SQLite's `CURRENT_TIMESTAMP` do not include millisecond information. The regex used by the date parser tries to find a string matching `yyyy-MM-dd HH:mm:ss.SSS` but the dates created by SQLite do not include the milliseconds `.SSS` so the date strings are not matching and this is causing the parser to return null. The solution implemented in this pull request detects this exact case (string length is exactly 19) and then appends `.000` to the source string. This causes the regex to match on the string allowing the date string to be parsed and the Date object to be returned. The source object is not mutated, and the extra characters do not change the `DATETIME` represented by the date string, so I think this is a safe fix.

Please let me know if you have any questions about this.