### PR TITLE
Revert "Normalize source string when parsing"

### DIFF
--- a/src/main/java/org/sqlite/date/FastDateParser.java
+++ b/src/main/java/org/sqlite/date/FastDateParser.java
@@ -288,16 +288,15 @@ public class FastDateParser implements DateParser, Serializable {
      * @see org.apache.commons.lang3.time.DateParser#parse(java.lang.String)
      */
     public Date parse(final String source) throws ParseException {
-        String normalizedSource = source.length() == 19 ? (source + ".000") : source;
-        final Date date= parse(normalizedSource, new ParsePosition(0));
+        final Date date= parse(source, new ParsePosition(0));
         if(date==null) {
             // Add a note re supported date range
             if (locale.equals(JAPANESE_IMPERIAL)) {
                 throw new ParseException(
                         "(The " +locale + " locale does not support dates before 1868 AD)\n" +
-                                "Unparseable date: \""+normalizedSource+"\" does not match "+parsePattern.pattern(), 0);
+                                "Unparseable date: \""+source+"\" does not match "+parsePattern.pattern(), 0);
             }
-            throw new ParseException("Unparseable date: \""+normalizedSource+"\" does not match "+parsePattern.pattern(), 0);
+            throw new ParseException("Unparseable date: \""+source+"\" does not match "+parsePattern.pattern(), 0);
         }
         return date;
     }

--- a/src/test/java/org/sqlite/StatementTest.java
+++ b/src/test/java/org/sqlite/StatementTest.java
@@ -421,18 +421,6 @@ public class StatementTest
         Date d = rs.getDate(1);
         assertEquals(day.getTime(), d.getTime());
     }
-    
-    @Test
-    public void defaultDateTimeTest() throws SQLException {
-        stat.executeUpdate("create table daywithdefaultdatetime (id integer, datetime datatime default current_timestamp)");
-        PreparedStatement prep = conn.prepareStatement("insert into daywithdefaultdatetime (id) values (1)");
-        prep.setInt(1, 1);
-        prep.executeUpdate();
-        ResultSet rs = stat.executeQuery("select * from day");
-        assertTrue(rs.next());
-        Date d = rs.getDate(2);
-        assertTrue(d != null);
-    }
 
     @Test
     public void maxRows() throws SQLException {


### PR DESCRIPTION
Reverts xerial/sqlite-jdbc#609 because of test failure