### PR TITLE
bring back armv6 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,8 +111,7 @@ NATIVE_TARGET_DIR:=$(TARGET)/classes/org/sqlite/native/$(OS_NAME)/$(OS_ARCH)
 NATIVE_DLL:=$(NATIVE_DIR)/$(LIBNAME)
 
 # For cross-compilation, install docker. See also https://github.com/dockcross/dockcross
-# Disabled linux-armv6 build because of this issue; https://github.com/dockcross/dockcross/issues/190
-native-all: native win32 win64 mac64 linux32 linux64 linux-arm linux-armv7 linux-arm64 linux-android-arm linux-ppc64 alpine-linux64
+native-all: native win32 win64 mac64 linux32 linux64 linux-arm linux-armv6 linux-armv7 linux-arm64 linux-android-arm linux-ppc64 alpine-linux64
 
 native: $(NATIVE_DLL)
 
@@ -143,7 +142,7 @@ linux-arm: $(SQLITE_UNPACKED) jni-header
 	./docker/dockcross-armv5 -a $(DOCKER_RUN_OPTS) bash -c 'make clean-native native CROSS_PREFIX=/usr/xcc/armv5-unknown-linux-gnueabi/bin/armv5-unknown-linux-gnueabi- OS_NAME=Linux OS_ARCH=arm'
 
 linux-armv6: $(SQLITE_UNPACKED) jni-header
-	./docker/dockcross-armv6 -a $(DOCKER_RUN_OPTS) bash -c 'make clean-native native CROSS_PREFIX=arm-linux-gnueabihf- OS_NAME=Linux OS_ARCH=armv6'
+	./docker/dockcross-armv6 -a $(DOCKER_RUN_OPTS) bash -c 'make clean-native native CROSS_PREFIX=/usr/xcc/armv6-unknown-linux-gnueabihf/bin/armv6-unknown-linux-gnueabihf- OS_NAME=Linux OS_ARCH=armv6'
 
 linux-armv7: $(SQLITE_UNPACKED) jni-header
 	./docker/dockcross-armv7a -a $(DOCKER_RUN_OPTS) bash -c 'make clean-native native CROSS_PREFIX=/usr/xcc/arm-cortexa8_neon-linux-gnueabihf/bin/arm-cortexa8_neon-linux-gnueabihf- OS_NAME=Linux OS_ARCH=armv7'

--- a/docker/dockcross-armv6
+++ b/docker/dockcross-armv6
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
 
-DEFAULT_DOCKCROSS_IMAGE=dockcross/linux-armv6:latest
+DEFAULT_DOCKCROSS_IMAGE=dockcross/linux-armv6-lts:latest
 
 #------------------------------------------------------------------------------
 # Helpers
 #
 err() {
-    echo -e >&2 ERROR: $@\\n
+    echo -e >&2 "ERROR: $*\n"
 }
 
 die() {
-    err $@
+    err "$*"
     exit 1
 }
 
@@ -187,6 +187,8 @@ FINAL_ARGS=${ARG_ARGS-${DOCKCROSS_ARGS}}
 UBUNTU_ON_WINDOWS=$([ -e /proc/version ] && grep -l Microsoft /proc/version || echo "")
 # MSYS, Git Bash, etc.
 MSYS=$([ -e /proc/version ] && grep -l MINGW /proc/version || echo "")
+# CYGWIN
+CYGWIN=$([ -e /proc/version ] && grep -l CYGWIN /proc/version || echo "")
 
 if [ -z "$UBUNTU_ON_WINDOWS" -a -z "$MSYS" ]; then
     USER_IDS=(-e BUILDER_UID="$( id -u )" -e BUILDER_GID="$( id -g )" -e BUILDER_USER="$( id -un )" -e BUILDER_GROUP="$( id -gn )")
@@ -209,6 +211,11 @@ elif [ -n "$MSYS" ]; then
     HOST_PWD=$PWD
     HOST_PWD=${HOST_PWD/\//}
     HOST_PWD=${HOST_PWD/\//:\/}
+elif [ -n "$CYGWIN" ]; then
+    for f in pwd readlink cygpath ; do
+        test -n "$(type "${f}" )" || { echo >&2 "Missing functionality (${f}) (in cygwin)." ; exit 1 ; } ;
+    done ;
+    HOST_PWD="$( cygpath -w "$( readlink -f "$( pwd ;)" ; )" ; )" ;
 else
     HOST_PWD=$PWD
     [ -L $HOST_PWD ] && HOST_PWD=$(readlink $HOST_PWD)
@@ -221,7 +228,11 @@ fi
 
 HOST_VOLUMES=
 if [ -e "$SSH_DIR" -a -z "$MSYS" ]; then
-    HOST_VOLUMES+="-v $SSH_DIR:/home/$(id -un)/.ssh"
+    if test -n "${CYGWIN}" ; then
+      HOST_VOLUMES+="-v $(cygpath -w ${SSH_DIR} ; ):/home/$(id -un)/.ssh" ;
+    else
+      HOST_VOLUMES+="-v $SSH_DIR:/home/$(id -un)/.ssh" ;
+    fi ;
 fi
 
 #------------------------------------------------------------------------------
@@ -257,10 +268,10 @@ exit $run_exit_code
 # This image is not intended to be run manually.
 #
 # To create a dockcross helper script for the
-# dockcross/linux-armv6:latest image, run:
+# dockcross/linux-armv6-lts:latest image, run:
 #
-# docker run --rm dockcross/linux-armv6:latest > dockcross-linux-armv6-latest
-# chmod +x dockcross-linux-armv6-latest
+# docker run --rm dockcross/linux-armv6-lts:latest > dockcross-linux-armv6-lts-latest
+# chmod +x dockcross-linux-armv6-lts-latest
 #
 # You may then wish to move the dockcross script to your PATH.
 #


### PR DESCRIPTION
Following the fix done in https://github.com/dockcross/dockcross/pull/510 we can bring back armv6 support

It would be good if someone with a Raspberry PI with armv6 could test this.

Closes #583 