### PR TITLE
[graalvm] Add necessary config for graalvm native-image compilation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,12 @@
       </resource>
       <resource>
         <directory>src/main/resources</directory>
+        <includes>
+          <include>META-INF/native-image/**</include>
+        </includes>
+      </resource>
+      <resource>
+        <directory>src/main/resources</directory>
         <targetPath>META-INF/services</targetPath>
         <includes>
           <include>java.sql.Driver</include>

--- a/src/main/resources/META-INF/native-image/org.xerial/sqlite-jdbc/jni-config.json
+++ b/src/main/resources/META-INF/native-image/org.xerial/sqlite-jdbc/jni-config.json
@@ -1,0 +1,52 @@
+[
+    {
+        "name":"org.sqlite.core.DB",
+        "allDeclaredMethods":true,
+        "allPublicMethods": true,
+        "allDeclaredFields":true,
+        "methods":[{"name":"<init>","parameterTypes":["java.lang.String", "java.lang.String", "org.sqlite.SQLiteConfig"] }]
+    },
+    {
+        "name":"org.sqlite.core.NativeDB",
+        "allDeclaredMethods":true,
+        "allPublicMethods": true,
+        "allDeclaredFields":true,
+        "methods":[{"name":"<init>","parameterTypes":["java.lang.String", "java.lang.String", "org.sqlite.SQLiteConfig"] }]
+    },
+    {
+        "name":"org.sqlite.BusyHandler",
+        "allDeclaredMethods":true,
+        "allPublicMethods": true,
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.sqlite.Function",
+        "allDeclaredMethods":true,
+        "allPublicMethods": true,
+        "allDeclaredFields":true,
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.sqlite.ProgressHandler",
+        "allDeclaredMethods":true,
+        "allPublicMethods": true,
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.sqlite.Function$Aggregate",
+        "allDeclaredMethods":true,
+        "allPublicMethods": true,
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.sqlite.Function$Window",
+        "allDeclaredMethods":true,
+        "allPublicMethods": true,
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.sqlite.core.DB$ProgressObserver",
+        "allDeclaredMethods":true,
+        "allPublicMethods": true
+    }
+]

--- a/src/main/resources/META-INF/native-image/org.xerial/sqlite-jdbc/native-image.properties
+++ b/src/main/resources/META-INF/native-image/org.xerial/sqlite-jdbc/native-image.properties
@@ -1,0 +1,1 @@
+Args=-H:IncludeResources=\".*/org/sqlite/.*|org/sqlite/.*|.*/sqlite-jdbc.properties\" \

--- a/src/main/resources/META-INF/native-image/org.xerial/sqlite-jdbc/reflect-config.json
+++ b/src/main/resources/META-INF/native-image/org.xerial/sqlite-jdbc/reflect-config.json
@@ -1,0 +1,52 @@
+[
+    {
+        "name":"org.sqlite.core.DB",
+        "allDeclaredMethods":true,
+        "allPublicMethods": true,
+        "allDeclaredFields":true,
+        "methods":[{"name":"<init>","parameterTypes":["java.lang.String", "java.lang.String", "org.sqlite.SQLiteConfig"] }]
+    },
+    {
+        "name":"org.sqlite.core.NativeDB",
+        "allDeclaredMethods":true,
+        "allPublicMethods": true,
+        "allDeclaredFields":true,
+        "methods":[{"name":"<init>","parameterTypes":["java.lang.String", "java.lang.String", "org.sqlite.SQLiteConfig"] }]
+    },
+    {
+        "name":"org.sqlite.BusyHandler",
+        "allDeclaredMethods":true,
+        "allPublicMethods": true,
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.sqlite.Function",
+        "allDeclaredMethods":true,
+        "allPublicMethods": true,
+        "allDeclaredFields":true,
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.sqlite.ProgressHandler",
+        "allDeclaredMethods":true,
+        "allPublicMethods": true,
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.sqlite.Function$Aggregate",
+        "allDeclaredMethods":true,
+        "allPublicMethods": true,
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.sqlite.Function$Window",
+        "allDeclaredMethods":true,
+        "allPublicMethods": true,
+        "methods":[{"name":"<init>","parameterTypes":[] }]
+    },
+    {
+        "name":"org.sqlite.core.DB$ProgressObserver",
+        "allDeclaredMethods":true,
+        "allPublicMethods": true
+    }
+]


### PR DESCRIPTION
Hello,
Following [this recommended way](https://www.graalvm.org/reference-manual/native-image/BuildConfiguration/#embedding-a-configuration-file) from Oracle's Graalvm, this should make it easier for others that want to use sqlite-jdbc in a native-image compiled with GraalVM, this way users don't need to add those configs manually as GraalVM will find it in the classpath if using sqlite-jdbc lib.

[This](https://github.com/ericdallo/sqlite-graalvm-sample) is a sample showing that config works
I was using [this lib](https://github.com/ericdallo/sqlite-jni-graal-fix) in other projects to fix those missing configs, but after compiling it in json correctly now it's possible to bring those configs to sqlite-jdbc to make it available to everyone, if this PR get merged, that lib could be deprecated/archived.