### PR TITLE
CI tests for Windows and MacOS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,6 @@ on:
   push:
     branches:
       - master
-      - github-actions
     paths:
       - '**.java'
       - '**.xml'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,8 +26,8 @@ jobs:
     name: test ${{ matrix.os }} jdk${{ matrix.java }}
     strategy:
       matrix:
-        java: [8, 11, 16]
         os: [ubuntu-latest, windows-latest, macos-latest]
+        java: [8, 11, 16]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,48 +24,11 @@ on:
 jobs:
   test_ubuntu:
     name: test Ubuntu jdk${{ matrix.java }}
-    runs-on: ubuntu-latest
     strategy:
       matrix:
         java: [8, 11, 16]
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
-        with:
-          java-version: ${{ matrix.java }}
-      - uses: actions/cache@v1
-        with:
-          path: ~/.cache
-          key: ${{ runner.os }}-jdk${{ matrix.java }}-${{ hashFiles('**/*.sbt') }}
-          restore-keys: ${{ runner.os }}-jdk${{ matrix.java }}-
-      - name: Test
-        run: mvn test
-
-  test_windows:
-    name: test Windows jdk${{ matrix.java }}
-    runs-on: windows-latest
-    strategy:
-      matrix:
-        java: [8, 11, 16]
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
-        with:
-          java-version: ${{ matrix.java }}
-      - uses: actions/cache@v1
-        with:
-          path: ~/.cache
-          key: ${{ runner.os }}-jdk${{ matrix.java }}-${{ hashFiles('**/*.sbt') }}
-          restore-keys: ${{ runner.os }}-jdk${{ matrix.java }}-
-      - name: Test
-        run: mvn test
-
-  test_mac:
-    name: test Mac jdk${{ matrix.java }}
-    runs-on: macos-latest
-    strategy:
-      matrix:
-        java: [8, 11, 16]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,3 +40,41 @@ jobs:
           restore-keys: ${{ runner.os }}-jdk${{ matrix.java }}-
       - name: Test
         run: mvn test
+
+  test_windows:
+    name: test Windows jdk${{ matrix.java }}
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        java: [8, 11, 16]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+      - uses: actions/cache@v1
+        with:
+          path: ~/.cache
+          key: ${{ runner.os }}-jdk${{ matrix.java }}-${{ hashFiles('**/*.sbt') }}
+          restore-keys: ${{ runner.os }}-jdk${{ matrix.java }}-
+      - name: Test
+        run: mvn test
+
+  test_mac:
+    name: test Mac jdk${{ matrix.java }}
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        java: [8, 11, 16]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+      - uses: actions/cache@v1
+        with:
+          path: ~/.cache
+          key: ${{ runner.os }}-jdk${{ matrix.java }}-${{ hashFiles('**/*.sbt') }}
+          restore-keys: ${{ runner.os }}-jdk${{ matrix.java }}-
+      - name: Test
+        run: mvn test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ on:
   push:
     branches:
       - master
+      - github-actions
     paths:
       - '**.java'
       - '**.xml'
@@ -21,48 +22,21 @@ on:
       - '.github/workflows/*.yml'
 
 jobs:
-  test:
-    name: test jdk11
+  test_ubuntu:
+    name: test Ubuntu jdk${{ matrix.java }}
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [8, 11, 16]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: ${{ matrix.java }}
       - uses: actions/cache@v1
         with:
           path: ~/.cache
-          key: ${{ runner.os }}-jdk11-${{ hashFiles('**/*.sbt') }}
-          restore-keys: ${{ runner.os }}-jdk11-
-      - name: Test
-        run: mvn test
-  test_jdk8:
-    name: test jdk8
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
-        with:
-          java-version: 8
-      - uses: actions/cache@v1
-        with:
-          path: ~/.cache
-          key: ${{ runner.os }}-jdk8-${{ hashFiles('**/*.sbt') }}
-          restore-keys: ${{ runner.os }}-jdk8-
-      - name: Test
-        run: mvn test
-  test_jdk16:
-    name: test jdk16
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
-        with:
-          java-version: 16
-      - uses: actions/cache@v1
-        with:
-          path: ~/.cache
-          key: ${{ runner.os }}-jdk8-${{ hashFiles('**/*.sbt') }}
-          restore-keys: ${{ runner.os }}-jdk8-
+          key: ${{ runner.os }}-jdk${{ matrix.java }}-${{ hashFiles('**/*.sbt') }}
+          restore-keys: ${{ runner.os }}-jdk${{ matrix.java }}-
       - name: Test
         run: mvn test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ on:
       - '.github/workflows/*.yml'
 
 jobs:
-  test_ubuntu:
+  test:
     name: test ${{ matrix.os }} jdk${{ matrix.java }}
     strategy:
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   test_ubuntu:
-    name: test jdk${{ matrix.java }} ${{ matrix.os }}
+    name: test ${{ matrix.os }} jdk${{ matrix.java }}
     strategy:
       matrix:
         java: [8, 11, 16]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   test_ubuntu:
-    name: test Ubuntu jdk${{ matrix.java }}
+    name: test jdk${{ matrix.java }} ${{ matrix.os }}
     strategy:
       matrix:
         java: [8, 11, 16]

--- a/src/test/java/org/sqlite/SQLiteJDBCLoaderTest.java
+++ b/src/test/java/org/sqlite/SQLiteJDBCLoaderTest.java
@@ -167,6 +167,7 @@ public class SQLiteJDBCLoaderTest
         File classesDir = null;
         String classesDirPrefix = null;
         for (String stringUrl : stringUrls) {
+            System.out.println(stringUrl);
             int indexOf = stringUrl.indexOf(targetFolderName);
             if (indexOf != -1) {
                 classesDir = new File(stringUrl);

--- a/src/test/java/org/sqlite/SQLiteJDBCLoaderTest.java
+++ b/src/test/java/org/sqlite/SQLiteJDBCLoaderTest.java
@@ -36,6 +36,7 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.file.Paths;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
@@ -163,11 +164,10 @@ public class SQLiteJDBCLoaderTest
         String[] stringUrls = System.getProperty("java.class.path")
                 .split(System.getProperty("path.separator"));
         // Find the classes under test.
-        String targetFolderName = "sqlite-jdbc/target/classes";
+        String targetFolderName = Paths.get("sqlite-jdbc","target","classes").toString();
         File classesDir = null;
         String classesDirPrefix = null;
         for (String stringUrl : stringUrls) {
-            System.out.println(stringUrl);
             int indexOf = stringUrl.indexOf(targetFolderName);
             if (indexOf != -1) {
                 classesDir = new File(stringUrl);


### PR DESCRIPTION
- converts the github workflow to use the matrix notation for Linux tests
- run tests on Windows and MacOS
- fix some tests failing on Windows (`SQLiteJDBCLoaderTest.multipleClassLoader`)

You can see a sample execution here: https://github.com/gotson/sqlite-jdbc/actions/runs/1150032640 (edit: or in the checks of this very PR)