### PR TITLE
Using TCK Tested JDK builds & fixed versions of OpenJDK

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        java: [ 8, 11, 16 ]
+        java: [ 8, 8.0.192, 11, 11.0.3, 16 ]
         exclude:
           - os: windows-latest
             java: 11
@@ -55,7 +55,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'zulu'
           java-version: ${{ matrix.java }}
           java-package: jdk
           cache: 'maven'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v2
         with:
-          distribution: 'zulu'
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
           java-package: jdk
           cache: 'maven'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        java: [ 8, 8.0.192, 11, 11.0.3, 16 ]
+        java: [ 8, 11, 16 ]
         exclude:
           - os: windows-latest
             java: 11


### PR DESCRIPTION
The AdoptOpenJDK has been discontinued since July 2021. When using Zulu you get all the latest updated (TCK Tested) builds for all versions of OpenJDK. Also added fixed (major) versions to the list of JDKs to build. This is good practice when customers or vendors are at fixed versions in production and using the latest can / has broken. If the fixed version is green (passed) and the latest is red (test failed) that means it isn’t your code that broke, but the latest build was the cause of the issue. 

As AdoptOpenJDK -> Adoptium -> Eclipse Foundation has suggested Temurin builds (which also are nice TCK tested builds) they do not support every version of OpenJDK such as many non-LTS versions and fixed version prior to july/aug 2021.