### PR TITLE
Use more specific types when fetching JDBC3ResultSet.getBigDecimal

### DIFF
--- a/src/main/java/org/sqlite/jdbc3/JDBC3ResultSet.java
+++ b/src/main/java/org/sqlite/jdbc3/JDBC3ResultSet.java
@@ -153,14 +153,28 @@ public abstract class JDBC3ResultSet extends CoreResultSet {
 
     /** @see java.sql.ResultSet#getBigDecimal(int) */
     public BigDecimal getBigDecimal(int col) throws SQLException {
-        final String stringValue = getString(col);
-        if (stringValue == null) {
-            return null;
+        final int columnType = getColumnType(col);
+
+        if (columnType == Types.INTEGER) {
+            long decimal = getLong(col);
+            return BigDecimal.valueOf(decimal);
+        } else if (columnType == Types.FLOAT || columnType == Types.DOUBLE) {
+            final double decimal = getDouble(col);
+            if (Double.isNaN(decimal)) {
+                throw new SQLException("Bad value for type BigDecimal : Not a Number");
+            } else {
+                return BigDecimal.valueOf(decimal);
+            }
         } else {
-            try {
-                return new BigDecimal(stringValue);
-            } catch (NumberFormatException e) {
-                throw new SQLException("Bad value for type BigDecimal : " + stringValue);
+            final String stringValue = getString(col);
+            if (stringValue == null) {
+                return null;
+            } else {
+                try {
+                    return new BigDecimal(stringValue);
+                } catch (NumberFormatException e) {
+                    throw new SQLException("Bad value for type BigDecimal : " + stringValue);
+                }
             }
         }
     }


### PR DESCRIPTION
For now when fetching BigDecimal via JDBC3ResultSet.getBigDecimal the string value representation is used and in some cases the precision is loosed when underneath type if Float or Decimal.

In the PR the decision on how to build BigDecimal is made based on the real column type (integer and decimal types are checked).
