### PR TITLE
Fix violations of Sonar rule 2184

### DIFF
--- a/src/test/java/org/sqlite/SQLiteJDBCLoaderTest.java
+++ b/src/test/java/org/sqlite/SQLiteJDBCLoaderTest.java
@@ -119,7 +119,7 @@ public class SQLiteJDBCLoaderTest {
                     new Runnable() {
                         public void run() {
                             try {
-                                Thread.sleep(sleepMillis * 10L );
+                                Thread.sleep(sleepMillis * 10L);
                             } catch (InterruptedException e) {
                             }
                             try {

--- a/src/test/java/org/sqlite/SQLiteJDBCLoaderTest.java
+++ b/src/test/java/org/sqlite/SQLiteJDBCLoaderTest.java
@@ -119,7 +119,7 @@ public class SQLiteJDBCLoaderTest {
                     new Runnable() {
                         public void run() {
                             try {
-                                Thread.sleep(sleepMillis * 10);
+                                Thread.sleep(sleepMillis * 10L );
                             } catch (InterruptedException e) {
                             }
                             try {


### PR DESCRIPTION
Hi,

This PR fixes 1 violations of [Sonar Rule 2184: 'Math operands should be cast before assignment'](https://rules.sonarsource.com/java/RSPEC-2184). This is done without introducing any new violations of Sonar rules.

The patch was generated automatically with the tool [Sorald](https://github.com/SpoonLabs/sorald). For details on the fix applied here, please see [Sorald's documentation on rule 2184](https://github.com/SpoonLabs/sorald/blob/master/docs/HANDLED_RULES.md#math-operands-should-be-cast-before-assignment-sonar-rule-2184).

P.S.: Note that this PR is not created/submitted by a bot. If you have any feedback, please leave them as comments.