### PR TITLE
Add test for FastDatePrinter.parsePattern and FastDatePrinter.selectNumberRule

### DIFF
--- a/src/test/java/org/sqlite/SQLiteConfigTest.java
+++ b/src/test/java/org/sqlite/SQLiteConfigTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.sql.SQLException;
 import java.util.Properties;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -34,7 +33,8 @@ public class SQLiteConfigTest {
 
     @Test
     public void testParsePatternAndSelectNumberRule() throws SQLException {
-        Assertions.assertThrows(IllegalArgumentException.class,
+        Assertions.assertThrows(
+                IllegalArgumentException.class,
                 () -> {
                     SQLiteConfig config = new SQLiteConfig();
                     config.setReadOnly(true);

--- a/src/test/java/org/sqlite/SQLiteConfigTest.java
+++ b/src/test/java/org/sqlite/SQLiteConfigTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.sql.SQLException;
 import java.util.Properties;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class SQLiteConfigTest {
@@ -28,5 +30,18 @@ public class SQLiteConfigTest {
         assertEquals(
                 SQLiteConfig.DateClass.REAL.name(),
                 properties.getProperty(SQLiteConfig.Pragma.DATE_CLASS.getPragmaName()));
+    }
+
+    @Test
+    public void testParsePatternAndSelectNumberRule() throws SQLException {
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> {
+                    SQLiteConfig config = new SQLiteConfig();
+                    config.setReadOnly(true);
+                    config.setDateStringFormat("yyyy/mUm/dd");
+                    config.setDatePrecision("seconds");
+                    config.setDateClass("real");
+                    Properties properties = config.toProperties();
+                });
     }
 }


### PR DESCRIPTION
Hey 😊
I want to contribute the following test:

Test that a `java.lang.IllegalArgumentException` is thrown when the parameter `dateStringFormat` of the method `SQLiteConfig.setDateStringFormat` is set to `yyyy/mUm/dd`.
This tests the methods [`FastDatePrinter.parsePattern`](https://github.com/xerial/sqlite-jdbc/blob/ada2b147dc858ef557a995e2f4ef25f7c65fc6a7/src/main/java/org/sqlite/date/FastDatePrinter.java#L155) and [`FastDatePrinter.selectNumberRule`](https://github.com/xerial/sqlite-jdbc/blob/ada2b147dc858ef557a995e2f4ef25f7c65fc6a7/src/main/java/org/sqlite/date/FastDatePrinter.java#L352).
This test is based on the test [`toProperites`](https://github.com/xerial/sqlite-jdbc/blob/ada2b147dc858ef557a995e2f4ef25f7c65fc6a7/src/test/java/org/sqlite/SQLiteConfigTest.java#L12).

Curious to hear what you think!

(I wrote this test as part of a research study at TU Delft. [Find out more](https://github.com/lacinoire/lacinoire/blob/main/README.md))