### PR TITLE
Use setUseCaches instead of setDefaultUseCaches

### DIFF
--- a/src/main/java/org/sqlite/SQLiteJDBCLoader.java
+++ b/src/main/java/org/sqlite/SQLiteJDBCLoader.java
@@ -273,7 +273,7 @@ public class SQLiteJDBCLoader {
         }
         try {
             URLConnection connection = url.openConnection();
-            connection.setDefaultUseCaches(false);
+            connection.setUseCaches(false);
             return connection.getInputStream();
         } catch (IOException e) {
             e.printStackTrace();


### PR DESCRIPTION
Use of setDefaultUseCaches impacts all URLClassLoaders and HttpURLConnections, which can lead to erratic behavior of non-sqlite components running on a system since the variable is static.

Related issue: #656