### PR TITLE
fix: empty result set should not be returned as closed

### DIFF
--- a/src/main/java/org/sqlite/core/CoreResultSet.java
+++ b/src/main/java/org/sqlite/core/CoreResultSet.java
@@ -25,16 +25,25 @@ import org.sqlite.SQLiteConnectionConfig;
 public abstract class CoreResultSet implements Codes {
     protected final CoreStatement stmt;
 
-    public boolean emptyResultSet = false; // false means we don't have results
-    public boolean open = false; // true means have results and can iterate them
-    public int maxRows; // max. number of rows as set by a Statement
-    public String[] cols = null; // if null, the RS is closed()
-    public String[] colsMeta = null; // same as cols, but used by Meta interface
+    /** If the result set does not have any rows. */
+    public boolean emptyResultSet = false;
+    /** If the result set is open. Doesn't mean it has results. */
+    public boolean open = false;
+    /** Maximum number of rows as set by a Statement */
+    public int maxRows;
+    /** if null, the RS is closed() */
+    public String[] cols = null;
+    /** same as cols, but used by Meta interface */
+    public String[] colsMeta = null;
+
     protected boolean[][] meta = null;
 
-    protected int limitRows; // 0 means no limit, must check against maxRows
-    protected int row = 0; // number of current row, starts at 1 (0 is for before loading data)
-    protected int lastCol; // last column accessed, for wasNull(). -1 if none
+    /** 0 means no limit, must check against maxRows */
+    protected int limitRows;
+    /** number of current row, starts at 1 (0 is for before loading data) */
+    protected int row = 0;
+    /** last column accessed, for wasNull(). -1 if none */
+    protected int lastCol;
 
     public boolean closeStmt;
     protected Map<String, Integer> columnNameToIndex = null;

--- a/src/main/java/org/sqlite/jdbc3/JDBC3ResultSet.java
+++ b/src/main/java/org/sqlite/jdbc3/JDBC3ResultSet.java
@@ -52,7 +52,7 @@ public abstract class JDBC3ResultSet extends CoreResultSet {
 
     /** @see java.sql.ResultSet#next() */
     public boolean next() throws SQLException {
-        if (!open) {
+        if (!open || emptyResultSet) {
             return false; // finished ResultSet
         }
         lastCol = -1;
@@ -126,7 +126,7 @@ public abstract class JDBC3ResultSet extends CoreResultSet {
 
     /** @see java.sql.ResultSet#isBeforeFirst() */
     public boolean isBeforeFirst() throws SQLException {
-        return open && row == 0;
+        return !emptyResultSet && open && row == 0;
     }
 
     /** @see java.sql.ResultSet#isFirst() */

--- a/src/main/java/org/sqlite/jdbc3/JDBC3Statement.java
+++ b/src/main/java/org/sqlite/jdbc3/JDBC3Statement.java
@@ -117,7 +117,7 @@ public abstract class JDBC3Statement extends CoreStatement {
 
         rs.cols = rs.colsMeta;
         rs.emptyResultSet = !resultsWaiting;
-        rs.open = resultsWaiting;
+        rs.open = true;
         resultsWaiting = false;
 
         return (ResultSet) rs;

--- a/src/test/java/org/sqlite/ResultSetTest.java
+++ b/src/test/java/org/sqlite/ResultSetTest.java
@@ -157,4 +157,11 @@ public class ResultSetTest {
         assertEquals(nonAsciiString, resultSet.getString(1));
         assertFalse(resultSet.next());
     }
+
+    @Test
+    public void testFindColumnOnEmptyResultSet() throws SQLException {
+        ResultSet resultSet = stat.executeQuery("select * from test where id = 0");
+        assertFalse(resultSet.next());
+        assertEquals(1, resultSet.findColumn("id"));
+    }
 }


### PR DESCRIPTION
relates to #744