### PR TITLE
SQLiteJDBCLoader Java 8 and `java.nio` file/path operations

### DIFF
--- a/src/main/java/org/sqlite/SQLiteConnection.java
+++ b/src/main/java/org/sqlite/SQLiteConnection.java
@@ -1,12 +1,13 @@
 package org.sqlite;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
@@ -306,18 +307,9 @@ public abstract class SQLiteConnection implements Connection {
             //            }
         }
 
-        byte[] buffer = new byte[8192]; // 8K buffer
-        FileOutputStream writer = new FileOutputStream(dbFile);
-        InputStream reader = resourceAddr.openStream();
-        try {
-            int bytesRead = 0;
-            while ((bytesRead = reader.read(buffer)) != -1) {
-                writer.write(buffer, 0, bytesRead);
-            }
+        try (InputStream reader = resourceAddr.openStream()) {
+            Files.copy(reader, dbFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
             return dbFile;
-        } finally {
-            writer.close();
-            reader.close();
         }
     }
 

--- a/src/main/java/org/sqlite/SQLiteJDBCLoader.java
+++ b/src/main/java/org/sqlite/SQLiteJDBCLoader.java
@@ -27,6 +27,7 @@ package org.sqlite;
 import java.io.*;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.file.*;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -196,57 +197,37 @@ public class SQLiteJDBCLoader {
                 String.format("sqlite-%s-%s-%s", getVersion(), uuid, libraryFileName);
         String extractedLckFileName = extractedLibFileName + ".lck";
 
-        File extractedLibFile = new File(targetFolder, extractedLibFileName);
-        File extractedLckFile = new File(targetFolder, extractedLckFileName);
+        Path extractedLibFile = Paths.get(targetFolder, extractedLibFileName);
+        Path extractedLckFile = Paths.get(targetFolder, extractedLckFileName);
 
         try {
             // Extract a native library file into the target directory
-            InputStream reader = getResourceAsStream(nativeLibraryFilePath);
-            if (!extractedLckFile.exists()) {
-                new FileOutputStream(extractedLckFile).close();
-            }
-            FileOutputStream writer = new FileOutputStream(extractedLibFile);
-            try {
-                byte[] buffer = new byte[8192];
-                int bytesRead = 0;
-                while ((bytesRead = reader.read(buffer)) != -1) {
-                    writer.write(buffer, 0, bytesRead);
+            try (InputStream reader = getResourceAsStream(nativeLibraryFilePath)) {
+                if (Files.notExists(extractedLckFile)) {
+                    Files.createFile(extractedLckFile);
                 }
+
+                Files.copy(reader, extractedLibFile, StandardCopyOption.REPLACE_EXISTING);
             } finally {
                 // Delete the extracted lib file on JVM exit.
-                extractedLibFile.deleteOnExit();
-                extractedLckFile.deleteOnExit();
-
-                if (writer != null) {
-                    writer.close();
-                }
-                if (reader != null) {
-                    reader.close();
-                }
+                extractedLibFile.toFile().deleteOnExit();
+                extractedLckFile.toFile().deleteOnExit();
             }
 
             // Set executable (x) flag to enable Java to load the native library
-            extractedLibFile.setReadable(true);
-            extractedLibFile.setWritable(true, true);
-            extractedLibFile.setExecutable(true);
+            extractedLibFile.toFile().setReadable(true);
+            extractedLibFile.toFile().setWritable(true, true);
+            extractedLibFile.toFile().setExecutable(true);
 
             // Check whether the contents are properly copied from the resource folder
             {
-                InputStream nativeIn = getResourceAsStream(nativeLibraryFilePath);
-                InputStream extractedLibIn = new FileInputStream(extractedLibFile);
-                try {
+                try (InputStream nativeIn = getResourceAsStream(nativeLibraryFilePath);
+                        InputStream extractedLibIn = Files.newInputStream(extractedLibFile)) {
                     if (!contentsEquals(nativeIn, extractedLibIn)) {
                         throw new RuntimeException(
                                 String.format(
                                         "Failed to write a native library file at %s",
                                         extractedLibFile));
-                    }
-                } finally {
-                    if (nativeIn != null) {
-                        nativeIn.close();
-                    }
-                    if (extractedLibIn != null) {
-                        extractedLibIn.close();
                     }
                 }
             }
@@ -301,7 +282,7 @@ public class SQLiteJDBCLoader {
                                 + name
                                 + ". osinfo: "
                                 + OSInfo.getNativeLibFolderPathForCurrentOS());
-                System.err.println(e);
+                e.printStackTrace();
                 return false;
             }
 
@@ -320,7 +301,7 @@ public class SQLiteJDBCLoader {
             return;
         }
 
-        List<String> triedPaths = new LinkedList<String>();
+        List<String> triedPaths = new LinkedList<>();
 
         // Try loading library from org.sqlite.lib.path library path */
         String sqliteNativeLibraryPath = System.getProperty("org.sqlite.lib.path");
@@ -438,7 +419,7 @@ public class SQLiteJDBCLoader {
                 version = version.trim().replaceAll("[^0-9\\.]", "");
             }
         } catch (IOException e) {
-            System.err.println(e);
+            e.printStackTrace();
         }
         return version;
     }

--- a/src/test/java/org/sqlite/SQLiteJDBCLoaderTest.java
+++ b/src/test/java/org/sqlite/SQLiteJDBCLoaderTest.java
@@ -24,9 +24,9 @@
 // --------------------------------------
 package org.sqlite;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -60,26 +60,25 @@ public class SQLiteJDBCLoaderTest {
     }
 
     @Test
-    public void query() throws ClassNotFoundException {
-        try {
-            Statement statement = connection.createStatement();
-            statement.setQueryTimeout(30); // set timeout to 30 sec.
+    public void query() {
+        // if e.getMessage() is "out of memory", it probably means no
+        // database file is found
+        assertDoesNotThrow(
+                () -> {
+                    Statement statement = connection.createStatement();
+                    statement.setQueryTimeout(30); // set timeout to 30 sec.
 
-            statement.executeUpdate("create table person ( id integer, name string)");
-            statement.executeUpdate("insert into person values(1, 'leo')");
-            statement.executeUpdate("insert into person values(2, 'yui')");
+                    statement.executeUpdate("create table person ( id integer, name string)");
+                    statement.executeUpdate("insert into person values(1, 'leo')");
+                    statement.executeUpdate("insert into person values(2, 'yui')");
 
-            ResultSet rs = statement.executeQuery("select * from person order by id");
-            while (rs.next()) {
-                // read the result set
-                rs.getInt(1);
-                rs.getString(2);
-            }
-        } catch (SQLException e) {
-            // if e.getMessage() is "out of memory", it probably means no
-            // database file is found
-            fail(e.getMessage());
-        }
+                    ResultSet rs = statement.executeQuery("select * from person order by id");
+                    while (rs.next()) {
+                        // read the result set
+                        rs.getInt(1);
+                        rs.getString(2);
+                    }
+                });
     }
 
     @Test
@@ -116,23 +115,19 @@ public class SQLiteJDBCLoaderTest {
             final String connStr = "jdbc:sqlite:target/sample-" + i + ".db";
             final int sleepMillis = i;
             pool.execute(
-                    new Runnable() {
-                        public void run() {
-                            try {
-                                Thread.sleep(sleepMillis * 10);
-                            } catch (InterruptedException e) {
-                            }
-                            try {
-                                // Uncomment the synchronized block and everything works.
-                                // synchronized (TestSqlite.class) {
-                                Connection conn = DriverManager.getConnection(connStr);
-                                // }
-                            } catch (SQLException e) {
-                                e.printStackTrace();
-                                fail(e.getLocalizedMessage());
-                            }
-                            completedThreads.incrementAndGet();
+                    () -> {
+                        try {
+                            Thread.sleep(sleepMillis * 10);
+                        } catch (InterruptedException ignored) {
                         }
+                        assertDoesNotThrow(
+                                () -> {
+                                    // Uncomment the synchronized block and everything works.
+                                    // synchronized (TestSqlite.class) {
+                                    Connection conn = DriverManager.getConnection(connStr);
+                                    // }
+                                });
+                        completedThreads.incrementAndGet();
                     });
         }
         pool.shutdown();


### PR DESCRIPTION
This PR updates some code about file/path handling to use `java.nio` and Java 8 methods. It also uses a lazy directory stream for the cleanup of old native libs, which would close #198.