### PR TITLE
Allow correct recognition of Android OS when running Termux environment

### DIFF
--- a/src/main/java/org/sqlite/util/OSInfo.java
+++ b/src/main/java/org/sqlite/util/OSInfo.java
@@ -111,7 +111,12 @@ public class OSInfo {
     }
 
     public static boolean isAndroid() {
-        return System.getProperty("java.runtime.name", "").toLowerCase().contains("android");
+        boolean firstCheck =
+                System.getProperty("java.runtime.name", "").toLowerCase().contains("android");
+        if (!firstCheck) {
+            return checkIfAndroidTermux();
+        }
+        return firstCheck;
     }
 
     public static boolean isMusl() {
@@ -255,5 +260,15 @@ public class OSInfo {
 
     static String translateArchNameToFolderName(String archName) {
         return archName.replaceAll("\\W", "");
+    }
+
+    static boolean checkIfAndroidTermux() {
+        String output;
+        try {
+            output = processRunner.runAndWaitFor("uname -o");
+        } catch (IOException | InterruptedException e) {
+            return false;
+        }
+        return output.toString().toLowerCase().contains("android");
     }
 }

--- a/src/main/java/org/sqlite/util/OSInfo.java
+++ b/src/main/java/org/sqlite/util/OSInfo.java
@@ -111,12 +111,19 @@ public class OSInfo {
     }
 
     public static boolean isAndroid() {
-        boolean firstCheck =
-                System.getProperty("java.runtime.name", "").toLowerCase().contains("android");
-        if (!firstCheck) {
-            return checkIfAndroidTermux();
+        return isAndroidRuntime() || isAndroidTermux();
+    }
+
+    public static boolean isAndroidRuntime() {
+        return System.getProperty("java.runtime.name", "").toLowerCase().contains("android");
+    }
+
+    public static boolean isAndroidTermux() {
+        try {
+            return processRunner.runAndWaitFor("uname -o").toLowerCase().contains("android");
+        } catch (Exception ignored) {
+            return false;
         }
-        return firstCheck;
     }
 
     public static boolean isMusl() {
@@ -260,15 +267,5 @@ public class OSInfo {
 
     static String translateArchNameToFolderName(String archName) {
         return archName.replaceAll("\\W", "");
-    }
-
-    static boolean checkIfAndroidTermux() {
-        String output;
-        try {
-            output = processRunner.runAndWaitFor("uname -o");
-        } catch (IOException | InterruptedException e) {
-            return false;
-        }
-        return output.toString().toLowerCase().contains("android");
     }
 }

--- a/src/test/java/org/sqlite/util/OSInfoTest.java
+++ b/src/test/java/org/sqlite/util/OSInfoTest.java
@@ -110,15 +110,35 @@ public class OSInfoTest {
     // it's unlikely we run tests on an Android device
     @Test
     void testIsNotAndroid() {
+        assertThat(OSInfo.isAndroidRuntime()).isFalse();
+        assertThat(OSInfo.isAndroidTermux()).isFalse();
         assertThat(OSInfo.isAndroid()).isFalse();
+    }
+
+    @Test
+    public void testIsAndroidTermux() throws Exception {
+        try {
+            ProcessRunner mockRunner = mock(ProcessRunner.class);
+            OSInfo.processRunner = mockRunner;
+            when(mockRunner.runAndWaitFor("uname -o")).thenReturn("Android");
+
+            assertThat(OSInfo.isAndroidTermux()).isTrue();
+            assertThat(OSInfo.isAndroidRuntime()).isFalse();
+            assertThat(OSInfo.isAndroid()).isTrue();
+        } finally {
+            OSInfo.processRunner = new ProcessRunner();
+        }
     }
 
     @Nested
     @SetSystemProperty(key = "java.runtime.name", value = "Java for Android")
     @SetSystemProperty(key = "os.name", value = "Linux for Android")
-    class Android {
+    class AndroidRuntime {
+
         @Test
-        public void testIsAndroid() {
+        public void testIsAndroidRuntime() {
+            assertThat(OSInfo.isAndroidRuntime()).isTrue();
+            assertThat(OSInfo.isAndroidTermux()).isFalse();
             assertThat(OSInfo.isAndroid()).isTrue();
         }
 


### PR DESCRIPTION
If `isAndroid()` check fails, `checkIfAndroidTermux()` is called which runs `uname -o` command and check if its output contains `android`. This should fix #789. 

Sample command output in Termux before changes:
![Screenshot_20221016-120121.png](https://user-images.githubusercontent.com/61787916/196029389-806d6c93-ba8e-49d9-8e2f-25fdb6108bed.png)

Sample command output in Termux after changes:
![Screenshot_20221016-120404.png](https://user-images.githubusercontent.com/61787916/196029453-2a88aad0-926b-4a79-837a-9428458e9e59.png)