### PR TITLE
correction of isNullable() in JDBC3ResultSet

### DIFF
--- a/src/main/java/org/sqlite/jdbc3/JDBC3ResultSet.java
+++ b/src/main/java/org/sqlite/jdbc3/JDBC3ResultSet.java
@@ -827,9 +827,21 @@ public abstract class JDBC3ResultSet extends CoreResultSet {
     /** @see java.sql.ResultSetMetaData#isNullable(int) */
     public int isNullable(int col) throws SQLException {
         checkMeta();
-        return meta[checkCol(col)][1]
+        return meta[checkCol(col)][0]
                 ? ResultSetMetaData.columnNoNulls
                 : ResultSetMetaData.columnNullable;
+    }
+
+    /**
+     * Indicates whether the values in the designated column are primary attributes.
+     *
+     * @param col the first column is 1, the second is 2, ...
+     * @return whether the given column correspond to a primary attribute or not
+     * @throws SQLException if a database access error occurs
+     */
+    public boolean isPrimary(int col) throws SQLException {
+        checkMeta();
+        return meta[checkCol(col)][1];
     }
 
     /** @see java.sql.ResultSetMetaData#isAutoIncrement(int) */

--- a/src/main/java/org/sqlite/jdbc3/JDBC3ResultSet.java
+++ b/src/main/java/org/sqlite/jdbc3/JDBC3ResultSet.java
@@ -832,18 +832,6 @@ public abstract class JDBC3ResultSet extends CoreResultSet {
                 : ResultSetMetaData.columnNullable;
     }
 
-    /**
-     * Indicates whether the values in the designated column are primary attributes.
-     *
-     * @param col the first column is 1, the second is 2, ...
-     * @return whether the given column correspond to a primary attribute or not
-     * @throws SQLException if a database access error occurs
-     */
-    public boolean isPrimary(int col) throws SQLException {
-        checkMeta();
-        return meta[checkCol(col)][1];
-    }
-
     /** @see java.sql.ResultSetMetaData#isAutoIncrement(int) */
     public boolean isAutoIncrement(int col) throws SQLException {
         checkMeta();

--- a/src/test/java/org/sqlite/RSMetaDataTest.java
+++ b/src/test/java/org/sqlite/RSMetaDataTest.java
@@ -13,8 +13,6 @@ import java.sql.Types;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.sqlite.jdbc3.JDBC3ResultSet;
-import org.sqlite.jdbc4.JDBC4ResultSet;
 
 public class RSMetaDataTest {
     private Connection conn;

--- a/src/test/java/org/sqlite/RSMetaDataTest.java
+++ b/src/test/java/org/sqlite/RSMetaDataTest.java
@@ -29,6 +29,9 @@ public class RSMetaDataTest {
                 "create table People (pid integer primary key autoincrement, "
                         + " firstname string(255), surname string(25,5), dob date);");
         stat.executeUpdate(
+                "create table Film (id integer primary key autoincrement, "
+                        + " title string(255) not null, length integer not null, budget real);");
+        stat.executeUpdate(
                 "insert into people values (null, 'Mohandas', 'Gandhi', " + " '1869-10-02');");
         meta = stat.executeQuery("select pid, firstname, surname from people;").getMetaData();
     }
@@ -60,9 +63,6 @@ public class RSMetaDataTest {
         assertThat(meta.isNullable(1)).isEqualTo(ResultSetMetaData.columnNullable);
         assertThat(meta.isNullable(2)).isEqualTo(ResultSetMetaData.columnNullable);
         assertThat(meta.isNullable(3)).isEqualTo(ResultSetMetaData.columnNullable);
-        assertThat(((JDBC3ResultSet) meta).isPrimary(1)).isTrue();
-        assertThat(((JDBC3ResultSet) meta).isPrimary(2)).isFalse();
-        assertThat(((JDBC3ResultSet) meta).isPrimary(3)).isFalse();
     }
 
     @Test
@@ -190,14 +190,11 @@ public class RSMetaDataTest {
 
     @Test
     public void nullable() throws SQLException {
-        meta = stat.executeQuery("select null;").getMetaData();
+        meta = stat.executeQuery("select * from film;").getMetaData();
         assertThat(meta.isNullable(1)).isEqualTo(ResultSetMetaData.columnNullable);
-    }
-
-    @Test
-    public void primary() throws SQLException {
-        meta = stat.executeQuery("select pid from people;").getMetaData();
-        assertThat(((JDBC4ResultSet) meta).isPrimary(1)).isTrue();
+        assertThat(meta.isNullable(2)).isEqualTo(ResultSetMetaData.columnNoNulls);
+        assertThat(meta.isNullable(3)).isEqualTo(ResultSetMetaData.columnNoNulls);
+        assertThat(meta.isNullable(4)).isEqualTo(ResultSetMetaData.columnNullable);
     }
 
     @Test

--- a/src/test/java/org/sqlite/RSMetaDataTest.java
+++ b/src/test/java/org/sqlite/RSMetaDataTest.java
@@ -13,6 +13,8 @@ import java.sql.Types;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.sqlite.jdbc3.JDBC3ResultSet;
+import org.sqlite.jdbc4.JDBC4ResultSet;
 
 public class RSMetaDataTest {
     private Connection conn;
@@ -55,9 +57,12 @@ public class RSMetaDataTest {
         assertThat(meta.isAutoIncrement(1)).isTrue();
         assertThat(meta.isAutoIncrement(2)).isFalse();
         assertThat(meta.isAutoIncrement(3)).isFalse();
-        assertThat(meta.isNullable(1)).isEqualTo(ResultSetMetaData.columnNoNulls);
+        assertThat(meta.isNullable(1)).isEqualTo(ResultSetMetaData.columnNullable);
         assertThat(meta.isNullable(2)).isEqualTo(ResultSetMetaData.columnNullable);
         assertThat(meta.isNullable(3)).isEqualTo(ResultSetMetaData.columnNullable);
+        assertThat(((JDBC3ResultSet) meta).isPrimary(1)).isTrue();
+        assertThat(((JDBC3ResultSet) meta).isPrimary(2)).isFalse();
+        assertThat(((JDBC3ResultSet) meta).isPrimary(3)).isFalse();
     }
 
     @Test
@@ -187,6 +192,12 @@ public class RSMetaDataTest {
     public void nullable() throws SQLException {
         meta = stat.executeQuery("select null;").getMetaData();
         assertThat(meta.isNullable(1)).isEqualTo(ResultSetMetaData.columnNullable);
+    }
+
+    @Test
+    public void primary() throws SQLException {
+        meta = stat.executeQuery("select pid from people;").getMetaData();
+        assertThat(((JDBC4ResultSet) meta).isPrimary(1)).isTrue();
     }
 
     @Test


### PR DESCRIPTION
changed isNullable() in JDBC3ResultSet to use first column of meta[checkCol(col)] as it returns [nullable, primary, auto_incremented]

added isPrimary() in JDBC3ResultSet to return the value of the second column of meta[checkCol(col)] added corresponding tests in RSMetaDataTest
corrected line 60 in columns test in RSMetaDataTest as a primary key attribute can be null in SQLite

## Example with table "test":
![create_test](https://user-images.githubusercontent.com/47000714/197358176-6803c8c5-170d-4006-9f70-9fc3e7b44308.PNG)
![isNullable_test](https://user-images.githubusercontent.com/47000714/197358179-519b845e-cb52-4390-aa01-d26ebdf97740.PNG)

## Example with table "test2":
![create_test2](https://user-images.githubusercontent.com/47000714/197358209-eaa937b3-0db6-4d0b-881d-aa266b776e48.PNG)
![isNullable_test2](https://user-images.githubusercontent.com/47000714/197358211-1a9246fe-43ec-4a5d-9f60-3fdb10bdc8fc.PNG)
