### PR TITLE
fix: graalVM native image with runtime class initialization

### DIFF
--- a/src/main/resources/META-INF/native-image/org.xerial/sqlite-jdbc/jni-config.json
+++ b/src/main/resources/META-INF/native-image/org.xerial/sqlite-jdbc/jni-config.json
@@ -1,5 +1,9 @@
 [
     {
+        "name":"java.lang.Throwable",
+        "methods":[{"name":"toString","parameterTypes":[] }]
+    },
+    {
         "name":"org.sqlite.core.DB",
         "allDeclaredMethods":true,
         "allPublicMethods": true,


### PR DESCRIPTION
sqlite-jdbc 3.40.0.0 does not correctly run in a GraalVM native image unless full build-time class initialization is done with `--initialize-at-build-time`. Full build time initialization is really hard, maybe impossible, for big reflection-heavy frameworks like Spring Boot, where I ran into this.

I did the recommended approach of using the GraalVM Tracing agent to run my .jar, and then seeing what metadata it generated. It reported JNI usage of Throwable.toString, which this adds. This got my Spring Boot 3.0.1 application working with sqlite-jdbc!

I feel that the most correct way to solve GraalVM native image hints would be to have automated tests that exercise all code-paths of sqlite-jdbc with the tracing agent, and then use that captured metadata. There may be other code paths that this does not cover, meaning that other usages of this may fail at runtime in a GraalVM native image.

Here's another user who ran into this same issue:
https://github.com/oracle/graal/issues/5558


This change should fix GraalVM native image run when doing runtime class initialization. Loading the native library needs JNI access to `java.lang.Throwable.toString`