### PR TITLE
links: use https for sqlite.org

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -43,7 +43,7 @@ Release 3.7.15-SNAPSHOT-2
 * Fixed clean target to remove previous driver builds
 * Issue #42 - Using shared in-memory with URI filename
     * Added support for URI filenames
-        1. <http://www.sqlite.org/uri.html> examples <http://www.sqlite.org/c3ref/open.html#urifilenameexamples>
+        1. <https://www.sqlite.org/uri.html> examples <https://www.sqlite.org/c3ref/open.html#urifilenameexamples>
 * Issue #47 - MetaData.getExportedKeys() returns empty string for a named foreign key
 * Issue #46 - org.sqlite.MetaData.getExportedKeys constructs incorrect SQL
 * Issue #44 - getExportedKeys throws Null Exception for foreign key without explicit primary column name
@@ -52,7 +52,7 @@ Release 3.7.15-SNAPSHOT-2
 * Issue #43 - ResultSetMetaData does not return the SQL Type if there are no results from the query.
     1. ResultSetMetaData.getColumnTypeName() now gets type from either 'create table' statement or CAST(expr AS TYPE) otherwise sqlite3_value_type.
     2. ResultSetMetaData.getColumnType() now parses the result from getColumnTypeName() to return a type.
-    3. Driver recognizes the types listed at <http://www.sqlite.org/datatype3.html#affname> under 'Affinity Name Examples'.
+    3. Driver recognizes the types listed at <https://www.sqlite.org/datatype3.html#affname> under 'Affinity Name Examples'.
 * Issue #36 - Fixed case where a calling PreparedStatement.clearParameters() after a ResultSet is opened, caused subsequent calls to the ResultSet to return null.
     1. PreparedStatement.clearParameters() now uses sqlite3_clear_bindings instead of sqlite3_reset.
     2. PreparedStatement.clearParameters() does not reset current ResultSet.
@@ -76,7 +76,7 @@ Release 3.7.15-SNAPSHOT
 * Issue #11 - Enhanced MetaData.getPrimaryKeys():
     1. Return named primary keys and correct key sequence.
     2. Also result set is ordered by column name as per JDBC spec.
-* Issue #1 - Added support for WAL JournalMode. <http://www.sqlite.org/wal.html>
-* Issue #4 - Enhanced SQLiteDataSource, SQLiteConfig and Conn to enable setting the transaction mode. <http://www.sqlite.org/lang_transaction.html>
+* Issue #1 - Added support for WAL JournalMode. <https://www.sqlite.org/wal.html>
+* Issue #4 - Enhanced SQLiteDataSource, SQLiteConfig and Conn to enable setting the transaction mode. <https://www.sqlite.org/lang_transaction.html>
 * Issue #5 - Fixed NativeDB.c errors when compiling with Visual Studio 2010.
 * Issue #2 - Fixed issue where SQLiteDataSource: setEncoding not working. And also enabled using UTF-8, UTF-16, UTF-16le, and UTF-16be.

--- a/NEWS.md
+++ b/NEWS.md
@@ -32,7 +32,7 @@
     * **Note**: Don't use 3.35.0 if you are Apple Silicon (M1) user. 3.35.0 failed to include M1 binary
 *   2020-12-10: sqlite-jdbc-3.34.0
     * Improved the performance of reading String columns
-    * Support URI file names (file://...) in backup/restore commands https://sqlite.org/uri.html
+    * Support URI file names (file://...) in backup/restore commands https://www.sqlite.org/uri.html
     * Show SQL strings in PreparedStatements.toString()
 *   2020-12-08: sqlite-jdbc-3.32.3.3
     * Apple Silicon (M1) support
@@ -83,16 +83,16 @@
 *   2017-06-22: sqlite-jdbc-3.19.3
     * Upgrade to SQLite [3.19.3](https://www.sqlite.org/releaselog/3_19_3.html)
 *   2017-05-18: sqlite-jdbc-3.18.0
-    * Upgrade to SQLite [3.18.0](http://sqlite.org/releaselog/3_18_0.html)
+    * Upgrade to SQLite [3.18.0](https://www.sqlite.org/releaselog/3_18_0.html)
 *   2017-01-10: sqlite-jdbc-3.16.1
-    * Upgrade to SQLite [3.16.1](https://sqlite.org/releaselog/3_16_1.html)
+    * Upgrade to SQLite [3.16.1](https://www.sqlite.org/releaselog/3_16_1.html)
     * Add experimental support for ppc64, armv5, v6 (Raspberry PI), v7 and android-arm.
     * Fix a bug in prepared statements #74
     * Building all native libraries using cross compilers in docker images
 *   2016-11-04: sqlite-jdbc-3.15.1
-    * Upgrade to SQLite [3.15.1](https://sqlite.org/releaselog/3_15_1.html)
+    * Upgrade to SQLite [3.15.1](https://www.sqlite.org/releaselog/3_15_1.html)
 *   2016-11-04: sqlite-jdbc-3.15.0
-    * Upgrade to SQLite [3.15.0](https://sqlite.org/releaselog/3_15_0.html)
+    * Upgrade to SQLite [3.15.0](https://www.sqlite.org/releaselog/3_15_0.html)
     * Cleanup extracted temp library files upon start
     * Fix various metadata problems
 
@@ -160,8 +160,8 @@
 
 
 *   2009 January 19th: sqlite-jdbc-3.6.10 released. This version is compatible with
-    sqlite version 3.6.10. <http://www.sqlite.org/releaselog/3_6_10.html>
-    * Added `READ_UNCOMMITTED` mode support for better query performance: (see also <http://www.sqlite.org/sharedcache.html> )
+    sqlite version 3.6.10. <https://www.sqlite.org/releaselog/3_6_10.html>
+    * Added `READ_UNCOMMITTED` mode support for better query performance: (see also <https://www.sqlite.org/sharedcache.html> )
 
         ```java
         // READ_UNCOMMITTED mode works only in shared_cache mode.
@@ -173,16 +173,16 @@
 
 
 *   2008 December 17th: sqlite-jdbc-3.6.7 released.
-    *   Related information: <http://www.sqlite.org/releaselog/3_6_7.html>
+    *   Related information: <https://www.sqlite.org/releaselog/3_6_7.html>
 *   2008 December 1st: sqlite-jdbc-3.6.6.2 released,
-    *   Fixed a bug incorporated in the version 3.6.6 <http://www.sqlite.org/releaselog/3_6_6_2.html>
+    *   Fixed a bug incorporated in the version 3.6.6 <https://www.sqlite.org/releaselog/3_6_6_2.html>
 *   2008 November 20th: sqlite-jdbc-3.6.6 release.
-    *   Related information sqlite-3.6.6 changes: <http://www.sqlite.org/releaselog/3_6_6.html>
+    *   Related information sqlite-3.6.6 changes: <https://www.sqlite.org/releaselog/3_6_6.html>
 *   2008 November 11th: sqlite-jdbc-3.6.4.1. A bug fix release
     *   Pure-java version didn't work correctly. Fixed in both 3.6.4.1 and 3.6.4.
         If you have already downloaded 3.6.4, please obtain the latest one on the download page.
 *   2008 October 16th: sqlite-jdbc-3.6.4 released.
-    *   Changes from SQLite 3.6.3: <http://www.sqlite.org/releaselog/3_6_4.html>
+    *   Changes from SQLite 3.6.3: <https://www.sqlite.org/releaselog/3_6_4.html>
     *   `R*-Tree` index and `UPDATE/DELTE` syntax with `LIMIT` clause are available from this build.
 *   2008 October 14th: sqlite-jdbc-3.6.3 released. Compatible with SQLite 3.6.3.
 *   2008 September 18th: sqlite-jdbc-3.6.2 released. Compatible with SQLite 3.6.2
@@ -202,7 +202,7 @@
 *   2008 May 1st: sqlite-jdbc is now in the maven central repository!
     [How to use SQLiteJDBC with Maven2](#using-sqlite-jdbc-with-maven2)
 *   2008 Mar. 18th: sqlite-jdbc-3.5.7 released.
-    *   This version corresponds to [SQLite 3.5.7](http://www.sqlite.org/releaselog/3_5_7.html).
+    *   This version corresponds to [SQLite 3.5.7](https://www.sqlite.org/releaselog/3_5_7.html).
 
 
 *   2008 Mar. 10th: sqlite-jdbc-v042 released.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![javadoc](https://javadoc.io/badge2/org.xerial/sqlite-jdbc/javadoc.svg)](https://javadoc.io/doc/org.xerial/sqlite-jdbc)
 [![Sonatype Nexus (Snapshots)](https://img.shields.io/nexus/s/org.xerial/sqlite-jdbc?color=blue&label=maven%20snapshot&server=https%3A%2F%2Foss.sonatype.org%2F)](https://oss.sonatype.org/content/repositories/snapshots/org/xerial/sqlite-jdbc/)
 
-SQLite JDBC is a library for accessing and creating [SQLite](http://sqlite.org) database files in Java.
+SQLite JDBC is a library for accessing and creating [SQLite](https://www.sqlite.org) database files in Java.
 
 Our SQLiteJDBC library requires no configuration since native libraries for major OSs, including Windows, macOS, Linux etc., are assembled into a single JAR (Java Archive) file.
 
@@ -13,7 +13,7 @@ Our SQLiteJDBC library requires no configuration since native libraries for majo
 
 :arrow_right: More usage examples and configuration are available in [USAGE.md](USAGE.md)
 
-SQLite JDBC is a library for accessing SQLite databases through the JDBC API. For the general usage of JDBC, see [JDBC Tutorial](http://docs.oracle.com/javase/tutorial/jdbc/index.html) or [Oracle JDBC Documentation](http://www.oracle.com/technetwork/java/javase/tech/index-jsp-136101.html).
+SQLite JDBC is a library for accessing SQLite databases through the JDBC API. For the general usage of JDBC, see [JDBC Tutorial](https://docs.oracle.com/javase/tutorial/jdbc/index.html) or [Oracle JDBC Documentation](https://www.oracle.com/technetwork/java/javase/tech/index-jsp-136101.html).
 
 1. [Download](#download) `sqlite-jdbc-(VERSION).jar`
 then append this jar file into your classpath.

--- a/SQLiteJDBC.wiki
+++ b/SQLiteJDBC.wiki
@@ -2,13 +2,13 @@
 
 = SQLite JDBC Driver =
 
-SQLite JDBC driver developed by [wiki:leo Taro L. Saito] is an extension of [http://www.zentus.com/sqlitejdbc Zentus's SQLite JDBC driver] that enables Java to access [http://sqlite.org SQLite] database files.
+SQLite JDBC driver developed by [wiki:leo Taro L. Saito] is an extension of [http://www.zentus.com/sqlitejdbc Zentus's SQLite JDBC driver] that enables Java to access [https://www.sqlite.org SQLite] database files.
 
 Our SQLiteJDBC library, developed as a part of [http://www.xerial.org Xerial project], requires no configuration since all native libraries for Windows, Mac OS X, Linux and pure-java SQLite, which works in any OS enviroment, are assembled into a single JAR (Java Archive) file. The usage is quite simple; [#Download Download] our sqlite-jdbc library, then append the library (JAR file) to your class path. See [#Usage the sample code]. 
 
 == What is different from Zentus's SQLite JDBC? ==
 
-The original Zentus's SQLite JDBC driver http://www.zentus.com/sqlitejdbc/ itself is an excellent utility for using [http://sqlite.org SQLite] databases from Java language, and our SQLiteJDBC library also relies on its implementation. However, its pure-java version, which totally translates c/c++ codes of SQLite into Java, is significantly slower compared to its native version, which uses SQLite binaries compiled for each OS (win, mac, linux). 
+The original Zentus's SQLite JDBC driver http://www.zentus.com/sqlitejdbc/ itself is an excellent utility for using [https://www.sqlite.org SQLite] databases from Java language, and our SQLiteJDBC library also relies on its implementation. However, its pure-java version, which totally translates c/c++ codes of SQLite into Java, is significantly slower compared to its native version, which uses SQLite binaries compiled for each OS (win, mac, linux). 
 
 To use the native version of sqlite-jdbc, user had to set a path to the native codes (dll, jnilib, so files, which are JNDI C programs) by using command-line arguments, e.g., -Djava.library.path=(path to the dll, jnilib, etc.), or -Dorg.sqlite.lib.path, etc. This process was error-prone and bothersome to tell every user to set these variables. Our SQLiteJDBC library completely does away these inconveniences. 
 
@@ -42,8 +42,8 @@ Connection conn = DriverManager.getConnection("jdbc:sqlite:sample.db", config.to
   * 2009 February 18th: sqlite-jdbc-3.6.11 released. 
     * Fixed a bug in !PrepStmt, which does not clear the batch contents after executeBatch(). [http://groups.google.com/group/xerial/browse_thread/thread/1fa83eb36f6d5dab Discussion].
 
-  * 2009 January 19th: sqlite-jdbc-3.6.10 released. This version is compatible with sqlite version 3.6.10. http://www.sqlite.org/releaselog/3_6_10.html
-    * Added READ_UNCOMMITTED mode support for better query performance: (see also http://www.sqlite.org/sharedcache.html )
+  * 2009 January 19th: sqlite-jdbc-3.6.10 released. This version is compatible with sqlite version 3.6.10. https://www.sqlite.org/releaselog/3_6_10.html
+    * Added READ_UNCOMMITTED mode support for better query performance: (see also https://www.sqlite.org/sharedcache.html )
 {{{
 #!java
  // READ_UNCOMMITTED mode works only in shared_cache mode.
@@ -52,12 +52,12 @@ Connection conn = DriverManager.getConnection("jdbc:sqlite:sample.db", config.to
  Connection conn = DriverManager.getConnection("jdbc:sqlite:", prop);
  conn.setTransactionIsolation(Conn.TRANSACTION_READ_UNCOMMITTED);
 }}}
-  * 2008 December 17th: sqlite-jdbc-3.6.7 released. Related information: http://www.sqlite.org/releaselog/3_6_7.html
-  * 2008 December 1st: sqlite-jdbc-3.6.6.2 released, which fixed a bug incorporated in the version 3.6.6 http://www.sqlite.org/releaselog/3_6_6_2.html 
-  * 2008 November 20th: sqlite-jdbc-3.6.6 release. sqlite-3.6.6 changes: http://www.sqlite.org/releaselog/3_6_6.html
-Å@* 2008 November 11th: sqlite-jdbc-3.6.4.1. A bug fix release 
+  * 2008 December 17th: sqlite-jdbc-3.6.7 released. Related information: https://www.sqlite.org/releaselog/3_6_7.html
+  * 2008 December 1st: sqlite-jdbc-3.6.6.2 released, which fixed a bug incorporated in the version 3.6.6 https://www.sqlite.org/releaselog/3_6_6_2.html 
+  * 2008 November 20th: sqlite-jdbc-3.6.6 release. sqlite-3.6.6 changes: https://www.sqlite.org/releaselog/3_6_6.html
+ÔøΩ@* 2008 November 11th: sqlite-jdbc-3.6.4.1. A bug fix release 
     * Pure-java version didn't work correctly. Fixed in both 3.6.4.1 and 3.6.4. If you have already downloaded 3.6.4, please obtain the latest one on the download page.
- * 2008 October 16th: sqlite-jdbc-3.6.4 released. Changes from SQLite 3.6.3: http://www.sqlite.org/releaselog/3_6_4.html 
+ * 2008 October 16th: sqlite-jdbc-3.6.4 released. Changes from SQLite 3.6.3: https://www.sqlite.org/releaselog/3_6_4.html 
    * R*-Tree index and UPDATE/DELTE syntax with LIMIT clause are available from this build.
  * 2008 October 14th: sqlite-jdbc-3.6.3 released. Compatible with SQLite 3.6.3.
  * 2008 September 18th: sqlite-jdbc-3.6.2 released. Compatible with SQLite 3.6.2 and contains pure-java and native versions.
@@ -68,7 +68,7 @@ Connection conn = DriverManager.getConnection("jdbc:sqlite:sample.db", config.to
  * 2008 May 20th: sqlite-jdbc-3.5.9 released.
  * 2008 May 20th: sqlite-jdbc-3.5.8 released (corresponding to SQLite 3.5.8 and sqlite-jdbc-v047). From this release, Windows, Mac OS X, Linux (i386, amd64) and Solaris (SunOS, sparcv9) libraries are bundled into one jar file.
  * 2008 May 1st: sqlite-jdbc is now in the maven central repository! [#UsingSQLiteJDBCwithMaven2 How to use SQLiteJDBC with Maven2]
- * 2008 Mar. 18th: sqlite-jdbc-3.5.7 released. This version corresponds to [http://www.sqlite.org/releaselog/3_5_7.html SQLite 3.5.7].
+ * 2008 Mar. 18th: sqlite-jdbc-3.5.7 released. This version corresponds to [https://www.sqlite.org/releaselog/3_5_7.html SQLite 3.5.7].
 
  * 2008 Mar. 10th: sqlite-jdbc-v042 released. Corresponding to SQLite 3.5.6, which integrates FTS3 (full text search). 
  * 2008 Jan. 31st: sqlite-jdbc-v038.4 released.   SQLiteJDBCLoder.initialize() is no longer requried. 

--- a/amalgamation_version.sh
+++ b/amalgamation_version.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Used to generate the version for the amalgamation download zip.
-# http://www.sqlite.org/download.html#encoding
+# https://www.sqlite.org/download.html#encoding
 # The version is encoded so that filenames sort in order of increasing version number when viewed using "ls".
 # For version 3.X.Y the filename encoding is 3XXYY00. For branch version 3.X.Y.Z, the encoding is 3XXYYZZ.
 version=""

--- a/src/main/ext/extension-functions.c
+++ b/src/main/ext/extension-functions.c
@@ -32,7 +32,7 @@ Usage instructions for applications calling the sqlite3 API functions:
   In your application, call sqlite3_enable_load_extension(db,1) to
   allow loading external libraries.  Then load the library libsqlitefunctions
   using sqlite3_load_extension; the third argument should be 0.
-  See http://www.sqlite.org/cvstrac/wiki?p=LoadableExtensions.
+  See https://www.sqlite.org/cvstrac/wiki?p=LoadableExtensions.
   Select statements may now use these functions, as in
   SELECT cos(radians(inclination)) FROM satsum WHERE satnum = 25544;
 
@@ -44,7 +44,7 @@ Usage instructions for the sqlite3 program:
    0.707106781186548
   Note: Loading extensions is by default prohibited as a
   security measure; see "Security Considerations" in
-  http://www.sqlite.org/cvstrac/wiki?p=LoadableExtensions.
+  https://www.sqlite.org/cvstrac/wiki?p=LoadableExtensions.
   If the sqlite3 program and library are built this
   way, you cannot use these functions from the program, you 
   must write your own program using the sqlite3 API, and call

--- a/src/main/java/org/sqlite/Function.java
+++ b/src/main/java/org/sqlite/Function.java
@@ -314,7 +314,7 @@ public abstract class Function {
          *
          * @throws SQLException
          * @see <a
-         *     href="http://www.sqlite.org/c3ref/aggregate_context.html">http://www.sqlite.org/c3ref/aggregate_context.html</a>
+         *     href="https://www.sqlite.org/c3ref/aggregate_context.html">https://www.sqlite.org/c3ref/aggregate_context.html</a>
          */
         protected abstract void xStep() throws SQLException;
 
@@ -323,7 +323,7 @@ public abstract class Function {
          *
          * @throws SQLException
          * @see <a
-         *     href="http://www.sqlite.org/c3ref/aggregate_context.html">http://www.sqlite.org/c3ref/aggregate_context.html</a>
+         *     href="https://www.sqlite.org/c3ref/aggregate_context.html">https://www.sqlite.org/c3ref/aggregate_context.html</a>
          */
         protected abstract void xFinal() throws SQLException;
 
@@ -344,7 +344,7 @@ public abstract class Function {
          *
          * @throws SQLException
          * @see <a
-         *     href="https://sqlite.org/windowfunctions.html#user_defined_aggregate_window_functions">https://sqlite.org/windowfunctions.html#user_defined_aggregate_window_functions</a>
+         *     href="https://www.sqlite.org/windowfunctions.html#user_defined_aggregate_window_functions">https://www.sqlite.org/windowfunctions.html#user_defined_aggregate_window_functions</a>
          */
         protected abstract void xInverse() throws SQLException;
 
@@ -353,7 +353,7 @@ public abstract class Function {
          *
          * @throws SQLException
          * @see <a
-         *     href="https://sqlite.org/windowfunctions.html#user_defined_aggregate_window_functions">https://sqlite.org/windowfunctions.html#user_defined_aggregate_window_functions</a>
+         *     href="https://www.sqlite.org/windowfunctions.html#user_defined_aggregate_window_functions">https://www.sqlite.org/windowfunctions.html#user_defined_aggregate_window_functions</a>
          */
         protected abstract void xValue() throws SQLException;
     }

--- a/src/main/java/org/sqlite/ProgressHandler.java
+++ b/src/main/java/org/sqlite/ProgressHandler.java
@@ -3,7 +3,7 @@ package org.sqlite;
 import java.sql.Connection;
 import java.sql.SQLException;
 
-/** https://sqlite.org/c3ref/progress_handler.html */
+/** https://www.sqlite.org/c3ref/progress_handler.html */
 public abstract class ProgressHandler {
     /**
      * Sets a progress handler for the connection.

--- a/src/main/java/org/sqlite/SQLiteConfig.java
+++ b/src/main/java/org/sqlite/SQLiteConfig.java
@@ -36,7 +36,7 @@ import java.util.TreeSet;
 /**
  * SQLite Configuration
  *
- * <p>See also http://www.sqlite.org/pragma.html
+ * <p>See also https://www.sqlite.org/pragma.html
  *
  * @author leo
  */
@@ -564,7 +564,7 @@ public class SQLiteConfig {
      *
      * @param mode The open mode.
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/c_open_autoproxy.html">http://www.sqlite.org/c3ref/c_open_autoproxy.html</a>
+     *     href="https://www.sqlite.org/c3ref/c_open_autoproxy.html">https://www.sqlite.org/c3ref/c_open_autoproxy.html</a>
      */
     public void setOpenMode(SQLiteOpenMode mode) {
         openModeFlag |= mode.flag;
@@ -575,7 +575,7 @@ public class SQLiteConfig {
      *
      * @param mode The open mode.
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/c_open_autoproxy.html">http://www.sqlite.org/c3ref/c_open_autoproxy.html</a>
+     *     href="https://www.sqlite.org/c3ref/c_open_autoproxy.html">https://www.sqlite.org/c3ref/c_open_autoproxy.html</a>
      */
     public void resetOpenMode(SQLiteOpenMode mode) {
         openModeFlag &= ~mode.flag;
@@ -587,7 +587,7 @@ public class SQLiteConfig {
      *
      * @param enable True to enable; false to disable.
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/enable_shared_cache.html">www.sqlite.org/c3ref/enable_shared_cache.html</a>
+     *     href="https://www.sqlite.org/c3ref/enable_shared_cache.html">www.sqlite.org/c3ref/enable_shared_cache.html</a>
      */
     public void setSharedCache(boolean enable) {
         set(Pragma.SHARED_CACHE, enable);
@@ -598,7 +598,7 @@ public class SQLiteConfig {
      *
      * @param enable True to enable; false to disable.
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/load_extension.html">www.sqlite.org/c3ref/load_extension.html</a>
+     *     href="https://www.sqlite.org/c3ref/load_extension.html">www.sqlite.org/c3ref/load_extension.html</a>
      */
     public void enableLoadExtension(boolean enable) {
         set(Pragma.LOAD_EXTENSION, enable);
@@ -627,7 +627,7 @@ public class SQLiteConfig {
      *
      * @param numberOfPages Cache size in number of pages.
      * @see <a
-     *     href="http://www.sqlite.org/pragma.html#pragma_cache_size">www.sqlite.org/pragma.html#pragma_cache_size</a>
+     *     href="https://www.sqlite.org/pragma.html#pragma_cache_size">www.sqlite.org/pragma.html#pragma_cache_size</a>
      */
     public void setCacheSize(int numberOfPages) {
         set(Pragma.CACHE_SIZE, numberOfPages);
@@ -638,7 +638,7 @@ public class SQLiteConfig {
      *
      * @param enable True to enable; false to disable.
      * @see <a
-     *     href="http://www.sqlite.org/pragma.html#pragma_case_sensitive_like">www.sqlite.org/pragma.html#pragma_case_sensitive_like</a>
+     *     href="https://www.sqlite.org/pragma.html#pragma_case_sensitive_like">www.sqlite.org/pragma.html#pragma_case_sensitive_like</a>
      */
     public void enableCaseSensitiveLike(boolean enable) {
         set(Pragma.CASE_SENSITIVE_LIKE, enable);
@@ -649,7 +649,7 @@ public class SQLiteConfig {
      *     DELETE statements return the number of rows they modified.
      * @param enable True to enable; false to disable.
      * @see <a
-     *     href="http://www.sqlite.org/pragma.html#pragma_count_changes">www.sqlite.org/pragma.html#pragma_count_changes</a>
+     *     href="https://www.sqlite.org/pragma.html#pragma_count_changes">www.sqlite.org/pragma.html#pragma_count_changes</a>
      */
     @Deprecated
     public void enableCountChanges(boolean enable) {
@@ -662,7 +662,7 @@ public class SQLiteConfig {
      *
      * @param numberOfPages Cache size in number of pages.
      * @see <a
-     *     href="http://www.sqlite.org/pragma.html#pragma_cache_size">www.sqlite.org/pragma.html#pragma_cache_size</a>
+     *     href="https://www.sqlite.org/pragma.html#pragma_cache_size">www.sqlite.org/pragma.html#pragma_cache_size</a>
      */
     public void setDefaultCacheSize(int numberOfPages) {
         set(Pragma.DEFAULT_CACHE_SIZE, numberOfPages);
@@ -683,7 +683,7 @@ public class SQLiteConfig {
      * @deprecated Enables or disables the empty_result_callbacks flag.
      * @param enable True to enable; false to disable. false.
      * @see <a
-     *     href="http://www.sqlite.org/pragma.html#pragma_empty_result_callbacks">http://www.sqlite.org/pragma.html#pragma_empty_result_callbacks</a>
+     *     href="https://www.sqlite.org/pragma.html#pragma_empty_result_callbacks">https://www.sqlite.org/pragma.html#pragma_empty_result_callbacks</a>
      */
     @Deprecated
     public void enableEmptyResultCallBacks(boolean enable) {
@@ -760,7 +760,7 @@ public class SQLiteConfig {
      *
      * @param encoding One of {@link Encoding}
      * @see <a
-     *     href="http://www.sqlite.org/pragma.html#pragma_encoding">www.sqlite.org/pragma.html#pragma_encoding</a>
+     *     href="https://www.sqlite.org/pragma.html#pragma_encoding">www.sqlite.org/pragma.html#pragma_encoding</a>
      */
     public void setEncoding(Encoding encoding) {
         setPragma(Pragma.ENCODING, encoding.typeName);
@@ -773,7 +773,7 @@ public class SQLiteConfig {
      *
      * @param enforce True to enable; false to disable.
      * @see <a
-     *     href="http://www.sqlite.org/pragma.html#pragma_foreign_keys">www.sqlite.org/pragma.html#pragma_foreign_keys</a>
+     *     href="https://www.sqlite.org/pragma.html#pragma_foreign_keys">www.sqlite.org/pragma.html#pragma_foreign_keys</a>
      */
     public void enforceForeignKeys(boolean enforce) {
         set(Pragma.FOREIGN_KEYS, enforce);
@@ -785,7 +785,7 @@ public class SQLiteConfig {
      *     SELECT statements.
      * @param enable True to enable; false to disable.
      * @see <a
-     *     href="http://www.sqlite.org/pragma.html#pragma_full_column_names">www.sqlite.org/pragma.html#pragma_full_column_names</a>
+     *     href="https://www.sqlite.org/pragma.html#pragma_full_column_names">www.sqlite.org/pragma.html#pragma_full_column_names</a>
      */
     @Deprecated
     public void enableFullColumnNames(boolean enable) {
@@ -799,7 +799,7 @@ public class SQLiteConfig {
      *
      * @param enable True to enable; false to disable.
      * @see <a
-     *     href="http://www.sqlite.org/pragma.html#pragma_fullfsync">www.sqlite.org/pragma.html#pragma_fullfsync</a>
+     *     href="https://www.sqlite.org/pragma.html#pragma_fullfsync">www.sqlite.org/pragma.html#pragma_fullfsync</a>
      */
     public void enableFullSync(boolean enable) {
         set(Pragma.FULL_SYNC, enable);
@@ -807,12 +807,12 @@ public class SQLiteConfig {
 
     /**
      * Sets the incremental_vacuum value; the number of pages to be removed from the <a
-     * href="http://www.sqlite.org/fileformat2.html#freelist">freelist</a>. The database file is
+     * href="https://www.sqlite.org/fileformat2.html#freelist">freelist</a>. The database file is
      * truncated by the same amount.
      *
      * @param numberOfPagesToBeRemoved The number of pages to be removed.
      * @see <a
-     *     href="http://www.sqlite.org/pragma.html#pragma_incremental_vacuum">www.sqlite.org/pragma.html#pragma_incremental_vacuum</a>
+     *     href="https://www.sqlite.org/pragma.html#pragma_incremental_vacuum">www.sqlite.org/pragma.html#pragma_incremental_vacuum</a>
      */
     public void incrementalVacuum(int numberOfPagesToBeRemoved) {
         set(Pragma.INCREMENTAL_VACUUM, numberOfPagesToBeRemoved);
@@ -823,7 +823,7 @@ public class SQLiteConfig {
      *
      * @param mode One of {@link JournalMode}
      * @see <a
-     *     href="http://www.sqlite.org/pragma.html#pragma_journal_mode">www.sqlite.org/pragma.html#pragma_journal_mode</a>
+     *     href="https://www.sqlite.org/pragma.html#pragma_journal_mode">www.sqlite.org/pragma.html#pragma_journal_mode</a>
      */
     public void setJournalMode(JournalMode mode) {
         setPragma(Pragma.JOURNAL_MODE, mode.name());
@@ -835,7 +835,7 @@ public class SQLiteConfig {
      *
      * @param limit Limit value in bytes. A negative number implies no limit.
      * @see <a
-     *     href="http://www.sqlite.org/pragma.html#pragma_journal_size_limit">www.sqlite.org/pragma.html#pragma_journal_size_limit</a>
+     *     href="https://www.sqlite.org/pragma.html#pragma_journal_size_limit">www.sqlite.org/pragma.html#pragma_journal_size_limit</a>
      */
     public void setJounalSizeLimit(int limit) {
         set(Pragma.JOURNAL_SIZE_LIMIT, limit);
@@ -849,7 +849,7 @@ public class SQLiteConfig {
      *
      * @param use True to turn on legacy file format; false to turn off.
      * @see <a
-     *     href="http://www.sqlite.org/pragma.html#pragma_legacy_file_format">www.sqlite.org/pragma.html#pragma_legacy_file_format</a>
+     *     href="https://www.sqlite.org/pragma.html#pragma_legacy_file_format">www.sqlite.org/pragma.html#pragma_legacy_file_format</a>
      */
     public void useLegacyFileFormat(boolean use) {
         set(Pragma.LEGACY_FILE_FORMAT, use);
@@ -869,7 +869,7 @@ public class SQLiteConfig {
      *
      * @param mode One of {@link LockingMode}
      * @see <a
-     *     href="http://www.sqlite.org/pragma.html#pragma_locking_mode">www.sqlite.org/pragma.html#pragma_locking_mode</a>
+     *     href="https://www.sqlite.org/pragma.html#pragma_locking_mode">www.sqlite.org/pragma.html#pragma_locking_mode</a>
      */
     public void setLockingMode(LockingMode mode) {
         setPragma(Pragma.LOCKING_MODE, mode.name());
@@ -881,7 +881,7 @@ public class SQLiteConfig {
      *
      * @param numBytes A power of two between 512 and 65536 inclusive.
      * @see <a
-     *     href="http://www.sqlite.org/pragma.html#pragma_page_size">www.sqlite.org/pragma.html#pragma_page_size</a>
+     *     href="https://www.sqlite.org/pragma.html#pragma_page_size">www.sqlite.org/pragma.html#pragma_page_size</a>
      */
     public void setPageSize(int numBytes) {
         set(Pragma.PAGE_SIZE, numBytes);
@@ -892,7 +892,7 @@ public class SQLiteConfig {
      *
      * @param numPages Number of pages.
      * @see <a
-     *     href="http://www.sqlite.org/pragma.html#pragma_max_page_count">www.sqlite.org/pragma.html#pragma_max_page_count</a>
+     *     href="https://www.sqlite.org/pragma.html#pragma_max_page_count">www.sqlite.org/pragma.html#pragma_max_page_count</a>
      */
     public void setMaxPageCount(int numPages) {
         set(Pragma.MAX_PAGE_COUNT, numPages);
@@ -903,7 +903,7 @@ public class SQLiteConfig {
      *
      * @param useReadUncommitedIsolationMode True to turn on; false to disable. disabled otherwise.
      * @see <a
-     *     href="http://www.sqlite.org/pragma.html#pragma_read_uncommitted">www.sqlite.org/pragma.html#pragma_read_uncommitted</a>
+     *     href="https://www.sqlite.org/pragma.html#pragma_read_uncommitted">www.sqlite.org/pragma.html#pragma_read_uncommitted</a>
      */
     public void setReadUncommited(boolean useReadUncommitedIsolationMode) {
         set(Pragma.READ_UNCOMMITTED, useReadUncommitedIsolationMode);
@@ -928,7 +928,7 @@ public class SQLiteConfig {
      *
      * @param enable True to enable reverse_unordered_selects.
      * @see <a
-     *     href="http://www.sqlite.org/pragma.html#pragma_reverse_unordered_selects">www.sqlite.org/pragma.html#pragma_reverse_unordered_selects</a>
+     *     href="https://www.sqlite.org/pragma.html#pragma_reverse_unordered_selects">www.sqlite.org/pragma.html#pragma_reverse_unordered_selects</a>
      */
     public void enableReverseUnorderedSelects(boolean enable) {
         set(Pragma.REVERSE_UNORDERED_SELECTS, enable);
@@ -940,7 +940,7 @@ public class SQLiteConfig {
      *
      * @param enable True to enable short_column_names.
      * @see <a
-     *     href="http://www.sqlite.org/pragma.html#pragma_short_column_names">www.sqlite.org/pragma.html#pragma_short_column_names</a>
+     *     href="https://www.sqlite.org/pragma.html#pragma_short_column_names">www.sqlite.org/pragma.html#pragma_short_column_names</a>
      */
     public void enableShortColumnNames(boolean enable) {
         set(Pragma.SHORT_COLUMN_NAMES, enable);
@@ -972,7 +972,7 @@ public class SQLiteConfig {
      *     </ul>
      *
      * @see <a
-     *     href="http://www.sqlite.org/pragma.html#pragma_synchronous">www.sqlite.org/pragma.html#pragma_synchronous</a>
+     *     href="https://www.sqlite.org/pragma.html#pragma_synchronous">www.sqlite.org/pragma.html#pragma_synchronous</a>
      */
     public void setSynchronous(SynchronousMode mode) {
         setPragma(Pragma.SYNCHRONOUS, mode.name());
@@ -1024,7 +1024,7 @@ public class SQLiteConfig {
      *     <li>MEMORY - temporary tables and indices are kept in as if they were pure in-memory
      *         databases memory
      * @see <a
-     *     href="http://www.sqlite.org/pragma.html#pragma_temp_store">www.sqlite.org/pragma.html#pragma_temp_store</a>
+     *     href="https://www.sqlite.org/pragma.html#pragma_temp_store">www.sqlite.org/pragma.html#pragma_temp_store</a>
      */
     public void setTempStore(TempStore storeType) {
         setPragma(Pragma.TEMP_STORE, storeType.name());
@@ -1036,7 +1036,7 @@ public class SQLiteConfig {
      *
      * @param directoryName Directory name for storing temporary tables and indices.
      * @see <a
-     *     href="http://www.sqlite.org/pragma.html#pragma_temp_store_directory">www.sqlite.org/pragma.html#pragma_temp_store_directory</a>
+     *     href="https://www.sqlite.org/pragma.html#pragma_temp_store_directory">www.sqlite.org/pragma.html#pragma_temp_store_directory</a>
      */
     public void setTempStoreDirectory(String directoryName) {
         setPragma(Pragma.TEMP_STORE_DIRECTORY, String.format("'%s'", directoryName));
@@ -1049,7 +1049,7 @@ public class SQLiteConfig {
      *
      * @param version A big-endian 32-bit signed integer.
      * @see <a
-     *     href="http://www.sqlite.org/pragma.html#pragma_user_version">www.sqlite.org/pragma.html#pragma_user_version</a>
+     *     href="https://www.sqlite.org/pragma.html#pragma_user_version">www.sqlite.org/pragma.html#pragma_user_version</a>
      */
     public void setUserVersion(int version) {
         set(Pragma.USER_VERSION, version);
@@ -1063,7 +1063,7 @@ public class SQLiteConfig {
      *
      * @param id A big-endian 32-bit unsigned integer.
      * @see <a
-     *     href="http://sqlite.org/pragma.html#pragma_application_id">www.sqlite.org/pragma.html#pragma_application_id</a>
+     *     href="https://www.sqlite.org/pragma.html#pragma_application_id">www.sqlite.org/pragma.html#pragma_application_id</a>
      */
     public void setApplicationId(int id) {
         set(Pragma.APPLICATION_ID, id);
@@ -1094,7 +1094,7 @@ public class SQLiteConfig {
      *
      * @param transactionMode One of {@link TransactionMode}.
      * @see <a
-     *     href="http://www.sqlite.org/lang_transaction.html">http://www.sqlite.org/lang_transaction.html</a>
+     *     href="https://www.sqlite.org/lang_transaction.html">https://www.sqlite.org/lang_transaction.html</a>
      */
     public void setTransactionMode(TransactionMode transactionMode) {
         this.defaultConnectionConfig.setTransactionMode(transactionMode);
@@ -1105,7 +1105,7 @@ public class SQLiteConfig {
      *
      * @param transactionMode One of DEFERRED, IMMEDIATE or EXCLUSIVE.
      * @see <a
-     *     href="http://www.sqlite.org/lang_transaction.html">http://www.sqlite.org/lang_transaction.html</a>
+     *     href="https://www.sqlite.org/lang_transaction.html">https://www.sqlite.org/lang_transaction.html</a>
      */
     public void setTransactionMode(String transactionMode) {
         setTransactionMode(TransactionMode.getMode(transactionMode));

--- a/src/main/java/org/sqlite/SQLiteConnection.java
+++ b/src/main/java/org/sqlite/SQLiteConnection.java
@@ -171,7 +171,7 @@ public abstract class SQLiteConnection implements Connection {
      *
      * @param mode One of {@link SQLiteConfig.TransactionMode}
      * @see <a
-     *     href="http://www.sqlite.org/lang_transaction.html">http://www.sqlite.org/lang_transaction.html</a>
+     *     href="https://www.sqlite.org/lang_transaction.html">https://www.sqlite.org/lang_transaction.html</a>
      */
     protected void setTransactionMode(SQLiteConfig.TransactionMode mode) {
         connectionConfig.setTransactionMode(mode);
@@ -212,7 +212,7 @@ public abstract class SQLiteConnection implements Connection {
      * Opens a connection to the database using an SQLite library. * @throws SQLException
      *
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/c_open_autoproxy.html">http://www.sqlite.org/c3ref/c_open_autoproxy.html</a>
+     *     href="https://www.sqlite.org/c3ref/c_open_autoproxy.html">https://www.sqlite.org/c3ref/c_open_autoproxy.html</a>
      */
     private static DB open(String url, String origFileName, Properties props) throws SQLException {
         // Create a copy of the given properties
@@ -369,7 +369,7 @@ public abstract class SQLiteConnection implements Connection {
     /**
      * @return The busy timeout value for the connection.
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/busy_timeout.html">http://www.sqlite.org/c3ref/busy_timeout.html</a>
+     *     href="https://www.sqlite.org/c3ref/busy_timeout.html">https://www.sqlite.org/c3ref/busy_timeout.html</a>
      */
     public int getBusyTimeout() {
         return db.getConfig().getBusyTimeout();
@@ -380,7 +380,7 @@ public abstract class SQLiteConnection implements Connection {
      * off all busy handlers.
      *
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/busy_timeout.html">http://www.sqlite.org/c3ref/busy_timeout.html</a>
+     *     href="https://www.sqlite.org/c3ref/busy_timeout.html">https://www.sqlite.org/c3ref/busy_timeout.html</a>
      * @param timeoutMillis The timeout value in milliseconds.
      * @throws SQLException
      */
@@ -428,7 +428,7 @@ public abstract class SQLiteConnection implements Connection {
      * @return Compile-time library version numbers.
      * @throws SQLException
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/c_source_id.html">http://www.sqlite.org/c3ref/c_source_id.html</a>
+     *     href="https://www.sqlite.org/c3ref/c_source_id.html">https://www.sqlite.org/c3ref/c_source_id.html</a>
      */
     public String libversion() throws SQLException {
         checkOpen();

--- a/src/main/java/org/sqlite/SQLiteDataSource.java
+++ b/src/main/java/org/sqlite/SQLiteDataSource.java
@@ -111,7 +111,7 @@ public class SQLiteDataSource implements DataSource {
      *
      * @param enable True to enable; false to disable.
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/enable_shared_cache.html">http://www.sqlite.org/c3ref/enable_shared_cache.html</a>
+     *     href="https://www.sqlite.org/c3ref/enable_shared_cache.html">https://www.sqlite.org/c3ref/enable_shared_cache.html</a>
      */
     public void setSharedCache(boolean enable) {
         config.setSharedCache(enable);
@@ -122,7 +122,7 @@ public class SQLiteDataSource implements DataSource {
      *
      * @param enable True to enable; false to disable.
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/load_extension.html">http://www.sqlite.org/c3ref/load_extension.html</a>
+     *     href="https://www.sqlite.org/c3ref/load_extension.html">https://www.sqlite.org/c3ref/load_extension.html</a>
      */
     public void setLoadExtension(boolean enable) {
         config.enableLoadExtension(enable);
@@ -133,7 +133,7 @@ public class SQLiteDataSource implements DataSource {
      *
      * @param readOnly True to enable; false to disable.
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/c_open_autoproxy.html">http://www.sqlite.org/c3ref/c_open_autoproxy.html</a>
+     *     href="https://www.sqlite.org/c3ref/c_open_autoproxy.html">https://www.sqlite.org/c3ref/c_open_autoproxy.html</a>
      */
     public void setReadOnly(boolean readOnly) {
         config.setReadOnly(readOnly);
@@ -145,7 +145,7 @@ public class SQLiteDataSource implements DataSource {
      *
      * @param numberOfPages The number of database disk pages.
      * @see <a
-     *     href="http://www.sqlite.org/pragma.html#pragma_cache_size">http://www.sqlite.org/pragma.html#pragma_cache_size</a>
+     *     href="https://www.sqlite.org/pragma.html#pragma_cache_size">https://www.sqlite.org/pragma.html#pragma_cache_size</a>
      */
     public void setCacheSize(int numberOfPages) {
         config.setCacheSize(numberOfPages);
@@ -156,7 +156,7 @@ public class SQLiteDataSource implements DataSource {
      *
      * @param enable True to enable; false to disable.
      * @see <a
-     *     href="http://www.sqlite.org/compile.html#case_sensitive_like">http://www.sqlite.org/compile.html#case_sensitive_like</a>
+     *     href="https://www.sqlite.org/compile.html#case_sensitive_like">https://www.sqlite.org/compile.html#case_sensitive_like</a>
      */
     public void setCaseSensitiveLike(boolean enable) {
         config.enableCaseSensitiveLike(enable);
@@ -168,7 +168,7 @@ public class SQLiteDataSource implements DataSource {
      *
      * @param enable True to enable; false to disable.
      * @see <a
-     *     href="http://www.sqlite.org/pragma.html#pragma_count_changes">http://www.sqlite.org/pragma.html#pragma_count_changes</a>
+     *     href="https://www.sqlite.org/pragma.html#pragma_count_changes">https://www.sqlite.org/pragma.html#pragma_count_changes</a>
      */
     public void setCountChanges(boolean enable) {
         config.enableCountChanges(enable);
@@ -180,7 +180,7 @@ public class SQLiteDataSource implements DataSource {
      *
      * @param numberOfPages The default suggested cache size.
      * @see <a
-     *     href="http://www.sqlite.org/pragma.html#pragma_cache_size">http://www.sqlite.org/pragma.html#pragma_cache_size</a>
+     *     href="https://www.sqlite.org/pragma.html#pragma_cache_size">https://www.sqlite.org/pragma.html#pragma_cache_size</a>
      */
     public void setDefaultCacheSize(int numberOfPages) {
         config.setDefaultCacheSize(numberOfPages);
@@ -191,8 +191,8 @@ public class SQLiteDataSource implements DataSource {
      *
      * @param encoding One of "UTF-8", "UTF-16le" (little-endian UTF-16) or "UTF-16be" (big-endian
      *     UTF-16).
-     * @see <a href="http://www.sqlite.org/pragma.html#pragma_encoding">
-     *     http://www.sqlite.org/pragma.html#pragma_encoding</a>
+     * @see <a href="https://www.sqlite.org/pragma.html#pragma_encoding">
+     *     https://www.sqlite.org/pragma.html#pragma_encoding</a>
      */
     public void setEncoding(String encoding) {
         config.setEncoding(Encoding.getEncoding(encoding));
@@ -202,8 +202,8 @@ public class SQLiteDataSource implements DataSource {
      * Enables or disables the enforcement of foreign key constraints.
      *
      * @param enforce True to enable; false to disable.
-     * @see <a href="http://www.sqlite.org/pragma.html#pragma_foreign_keys">
-     *     http://www.sqlite.org/pragma.html#pragma_foreign_keys</a>
+     * @see <a href="https://www.sqlite.org/pragma.html#pragma_foreign_keys">
+     *     https://www.sqlite.org/pragma.html#pragma_foreign_keys</a>
      */
     public void setEnforceForeignKeys(boolean enforce) {
         config.enforceForeignKeys(enforce);
@@ -216,7 +216,7 @@ public class SQLiteDataSource implements DataSource {
      *
      * @param enable True to enable; false to disable.
      * @see <a
-     *     href="http://www.sqlite.org/pragma.html#pragma_full_column_names">http://www.sqlite.org/pragma.html#pragma_full_column_names</a>
+     *     href="https://www.sqlite.org/pragma.html#pragma_full_column_names">https://www.sqlite.org/pragma.html#pragma_full_column_names</a>
      */
     public void setFullColumnNames(boolean enable) {
         config.enableFullColumnNames(enable);
@@ -228,7 +228,7 @@ public class SQLiteDataSource implements DataSource {
      *
      * @param enable True to enable; false to disable.
      * @see <a
-     *     href="http://www.sqlite.org/pragma.html#pragma_fullfsync">http://www.sqlite.org/pragma.html#pragma_fullfsync</a>
+     *     href="https://www.sqlite.org/pragma.html#pragma_fullfsync">https://www.sqlite.org/pragma.html#pragma_fullfsync</a>
      */
     public void setFullSync(boolean enable) {
         config.enableFullSync(enable);
@@ -236,11 +236,11 @@ public class SQLiteDataSource implements DataSource {
 
     /**
      * Set the incremental_vacuum value that causes up to N pages to be removed from the <a
-     * href="http://www.sqlite.org/fileformat2.html#freelist">http://www.sqlite.org/fileformat2.html#freelist</a>.
+     * href="https://www.sqlite.org/fileformat2.html#freelist">https://www.sqlite.org/fileformat2.html#freelist</a>.
      *
      * @param numberOfPagesToBeRemoved
-     * @see <a href="http://www.sqlite.org/pragma.html#pragma_incremental_vacuum">
-     *     http://www.sqlite.org/pragma.html#pragma_incremental_vacuum</a>
+     * @see <a href="https://www.sqlite.org/pragma.html#pragma_incremental_vacuum">
+     *     https://www.sqlite.org/pragma.html#pragma_incremental_vacuum</a>
      */
     public void setIncrementalVacuum(int numberOfPagesToBeRemoved) {
         config.incrementalVacuum(numberOfPagesToBeRemoved);
@@ -250,8 +250,8 @@ public class SQLiteDataSource implements DataSource {
      * Sets the journal mode for databases associated with the current database connection.
      *
      * @param mode One of DELETE, TRUNCATE, PERSIST, MEMORY, WAL or OFF.
-     * @see <a href="http://www.sqlite.org/pragma.html#pragma_journal_mode">
-     *     http://www.sqlite.org/pragma.html#pragma_journal_mode</a>
+     * @see <a href="https://www.sqlite.org/pragma.html#pragma_journal_mode">
+     *     https://www.sqlite.org/pragma.html#pragma_journal_mode</a>
      */
     public void setJournalMode(String mode) {
         config.setJournalMode(JournalMode.valueOf(mode));
@@ -262,8 +262,8 @@ public class SQLiteDataSource implements DataSource {
      * transactions or checkpoints.
      *
      * @param limit The default journal size limit is -1 (no limit).
-     * @see <a href="http://www.sqlite.org/pragma.html#pragma_journal_size_limit">
-     *     http://www.sqlite.org/pragma.html#pragma_journal_size_limit</a>
+     * @see <a href="https://www.sqlite.org/pragma.html#pragma_journal_size_limit">
+     *     https://www.sqlite.org/pragma.html#pragma_journal_size_limit</a>
      */
     public void setJournalSizeLimit(int limit) {
         config.setJounalSizeLimit(limit);
@@ -277,7 +277,7 @@ public class SQLiteDataSource implements DataSource {
      *
      * @param use True to turn on; false to turn off.
      * @see <a
-     *     href="http://www.sqlite.org/pragma.html#pragma_legacy_file_format">http://www.sqlite.org/pragma.html#pragma_legacy_file_format</a>
+     *     href="https://www.sqlite.org/pragma.html#pragma_legacy_file_format">https://www.sqlite.org/pragma.html#pragma_legacy_file_format</a>
      */
     public void setLegacyFileFormat(boolean use) {
         config.useLegacyFileFormat(use);
@@ -287,8 +287,8 @@ public class SQLiteDataSource implements DataSource {
      * Sets the database connection locking-mode.
      *
      * @param mode Either NORMAL or EXCLUSIVE.
-     * @see <a href="http://www.sqlite.org/pragma.html#pragma_locking_mode">
-     *     http://www.sqlite.org/pragma.html#pragma_locking_mode</a>
+     * @see <a href="https://www.sqlite.org/pragma.html#pragma_locking_mode">
+     *     https://www.sqlite.org/pragma.html#pragma_locking_mode</a>
      */
     public void setLockingMode(String mode) {
         config.setLockingMode(LockingMode.valueOf(mode));
@@ -298,8 +298,8 @@ public class SQLiteDataSource implements DataSource {
      * Set the page size of the database.
      *
      * @param numBytes The page size must be a power of two between 512 and 65536 inclusive.
-     * @see <a href="http://www.sqlite.org/pragma.html#pragma_page_size">
-     *     http://www.sqlite.org/pragma.html#pragma_page_size</a>
+     * @see <a href="https://www.sqlite.org/pragma.html#pragma_page_size">
+     *     https://www.sqlite.org/pragma.html#pragma_page_size</a>
      */
     public void setPageSize(int numBytes) {
         config.setPageSize(numBytes);
@@ -309,8 +309,8 @@ public class SQLiteDataSource implements DataSource {
      * Set the maximum number of pages in the database file.
      *
      * @param numPages The maximum page count cannot be reduced below the current database size.
-     * @see <a href="http://www.sqlite.org/pragma.html#pragma_max_page_count">
-     *     http://www.sqlite.org/pragma.html#pragma_max_page_count</a>
+     * @see <a href="https://www.sqlite.org/pragma.html#pragma_max_page_count">
+     *     https://www.sqlite.org/pragma.html#pragma_max_page_count</a>
      */
     public void setMaxPageCount(int numPages) {
         config.setMaxPageCount(numPages);
@@ -321,7 +321,7 @@ public class SQLiteDataSource implements DataSource {
      *
      * @param useReadUncommitedIsolationMode True to turn on; false to turn off.
      * @see <a
-     *     href="http://www.sqlite.org/pragma.html#pragma_read_uncommitted">http://www.sqlite.org/pragma.html#pragma_read_uncommitted</a>
+     *     href="https://www.sqlite.org/pragma.html#pragma_read_uncommitted">https://www.sqlite.org/pragma.html#pragma_read_uncommitted</a>
      */
     public void setReadUncommited(boolean useReadUncommitedIsolationMode) {
         config.setReadUncommited(useReadUncommitedIsolationMode);
@@ -334,7 +334,7 @@ public class SQLiteDataSource implements DataSource {
      *
      * @param enable True to enable; fase to disable.
      * @see <a
-     *     href="http://www.sqlite.org/pragma.html#pragma_recursive_triggers">http://www.sqlite.org/pragma.html#pragma_recursive_triggers</a>
+     *     href="https://www.sqlite.org/pragma.html#pragma_recursive_triggers">https://www.sqlite.org/pragma.html#pragma_recursive_triggers</a>
      */
     public void setRecursiveTriggers(boolean enable) {
         config.enableRecursiveTriggers(enable);
@@ -347,7 +347,7 @@ public class SQLiteDataSource implements DataSource {
      *
      * @param enable True to enable; fase to disable.
      * @see <a
-     *     href="http://www.sqlite.org/pragma.html#pragma_reverse_unordered_selects">http://www.sqlite.org/pragma.html#pragma_reverse_unordered_selects</a>
+     *     href="https://www.sqlite.org/pragma.html#pragma_reverse_unordered_selects">https://www.sqlite.org/pragma.html#pragma_reverse_unordered_selects</a>
      */
     public void setReverseUnorderedSelects(boolean enable) {
         config.enableReverseUnorderedSelects(enable);
@@ -359,9 +359,9 @@ public class SQLiteDataSource implements DataSource {
      *
      * @param enable True to enable; fase to disable.
      * @see <a
-     *     href="http://www.sqlite.org/pragma.html#pragma_short_column_names">http://www.sqlite.org/pragma.html#pragma_short_column_names</a>
+     *     href="https://www.sqlite.org/pragma.html#pragma_short_column_names">https://www.sqlite.org/pragma.html#pragma_short_column_names</a>
      * @see <a
-     *     href="http://www.sqlite.org/pragma.html#pragma_fullfsync">http://www.sqlite.org/pragma.html#pragma_fullfsync</a>
+     *     href="https://www.sqlite.org/pragma.html#pragma_fullfsync">https://www.sqlite.org/pragma.html#pragma_fullfsync</a>
      */
     public void setShortColumnNames(boolean enable) {
         config.enableShortColumnNames(enable);
@@ -371,8 +371,8 @@ public class SQLiteDataSource implements DataSource {
      * Sets the setting of the "synchronous" flag.
      *
      * @param mode One of OFF, NORMAL or FULL;
-     * @see <a href="http://www.sqlite.org/pragma.html#pragma_synchronous">
-     *     http://www.sqlite.org/pragma.html#pragma_synchronous</a>
+     * @see <a href="https://www.sqlite.org/pragma.html#pragma_synchronous">
+     *     https://www.sqlite.org/pragma.html#pragma_synchronous</a>
      */
     public void setSynchronous(String mode) {
         config.setSynchronous(SynchronousMode.valueOf(mode));
@@ -384,7 +384,7 @@ public class SQLiteDataSource implements DataSource {
      *
      * @param storeType One of "DEFAULT", "FILE", "MEMORY"
      * @see <a
-     *     href="http://www.sqlite.org/pragma.html#pragma_temp_store">http://www.sqlite.org/pragma.html#pragma_temp_store</a>
+     *     href="https://www.sqlite.org/pragma.html#pragma_temp_store">https://www.sqlite.org/pragma.html#pragma_temp_store</a>
      */
     public void setTempStore(String storeType) {
         config.setTempStore(TempStore.valueOf(storeType));
@@ -396,7 +396,7 @@ public class SQLiteDataSource implements DataSource {
      *
      * @param directoryName The temporary directory name.
      * @see <a
-     *     href="http://www.sqlite.org/pragma.html#pragma_temp_store_directory">http://www.sqlite.org/pragma.html#pragma_temp_store_directory</a>
+     *     href="https://www.sqlite.org/pragma.html#pragma_temp_store_directory">https://www.sqlite.org/pragma.html#pragma_temp_store_directory</a>
      */
     public void setTempStoreDirectory(String directoryName) {
         config.setTempStoreDirectory(directoryName);
@@ -407,7 +407,7 @@ public class SQLiteDataSource implements DataSource {
      *
      * @param transactionMode One of DEFERRED, IMMEDIATE or EXCLUSIVE.
      * @see <a
-     *     href="http://www.sqlite.org/lang_transaction.html">http://www.sqlite.org/lang_transaction.html</a>
+     *     href="https://www.sqlite.org/lang_transaction.html">https://www.sqlite.org/lang_transaction.html</a>
      */
     public void setTransactionMode(String transactionMode) {
         config.setTransactionMode(transactionMode);
@@ -419,7 +419,7 @@ public class SQLiteDataSource implements DataSource {
      *
      * @param version
      * @see <a
-     *     href="http://www.sqlite.org/pragma.html#pragma_schema_version">http://www.sqlite.org/pragma.html#pragma_schema_version</a>
+     *     href="https://www.sqlite.org/pragma.html#pragma_schema_version">https://www.sqlite.org/pragma.html#pragma_schema_version</a>
      */
     public void setUserVersion(int version) {
         config.setUserVersion(version);

--- a/src/main/java/org/sqlite/SQLiteErrorCode.java
+++ b/src/main/java/org/sqlite/SQLiteErrorCode.java
@@ -29,7 +29,7 @@ package org.sqlite;
  *
  * @author leo
  * @see <a
- *     href="http://www.sqlite.org/c3ref/c_abort.html">http://www.sqlite.org/c3ref/c_abort.html</a>
+ *     href="https://www.sqlite.org/c3ref/c_abort.html">https://www.sqlite.org/c3ref/c_abort.html</a>
  */
 public enum SQLiteErrorCode {
     UNKNOWN_ERROR(-1, "unknown error"),

--- a/src/main/java/org/sqlite/SQLiteOpenMode.java
+++ b/src/main/java/org/sqlite/SQLiteOpenMode.java
@@ -27,7 +27,7 @@ package org.sqlite;
 /**
  * Database file open modes of SQLite.
  *
- * <p>See also http://sqlite.org/c3ref/open.html
+ * <p>See also https://www.sqlite.org/c3ref/open.html
  *
  * @author leo
  */

--- a/src/main/java/org/sqlite/core/DB.java
+++ b/src/main/java/org/sqlite/core/DB.java
@@ -85,29 +85,29 @@ public abstract class DB implements Codes {
      *
      * @throws SQLException
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/interrupt.html">http://www.sqlite.org/c3ref/interrupt.html</a>
+     *     href="https://www.sqlite.org/c3ref/interrupt.html">https://www.sqlite.org/c3ref/interrupt.html</a>
      */
     public abstract void interrupt() throws SQLException;
 
     /**
-     * Sets a <a href="http://www.sqlite.org/c3ref/busy_handler.html">busy handler</a> that sleeps
+     * Sets a <a href="https://www.sqlite.org/c3ref/busy_handler.html">busy handler</a> that sleeps
      * for a specified amount of time when a table is locked.
      *
      * @param ms Time to sleep in milliseconds.
      * @throws SQLException
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/busy_timeout.html">http://www.sqlite.org/c3ref/busy_timeout.html</a>
+     *     href="https://www.sqlite.org/c3ref/busy_timeout.html">https://www.sqlite.org/c3ref/busy_timeout.html</a>
      */
     public abstract void busy_timeout(int ms) throws SQLException;
 
     /**
-     * Sets a <a href="http://www.sqlite.org/c3ref/busy_handler.html">busy handler</a> that sleeps
+     * Sets a <a href="https://www.sqlite.org/c3ref/busy_handler.html">busy handler</a> that sleeps
      * for a specified amount of time when a table is locked.
      *
      * @param busyHandler
      * @throws SQLException
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/busy_handler.html">http://www.sqlite.org/c3ref/busy_timeout.html</a>
+     *     href="https://www.sqlite.org/c3ref/busy_handler.html">https://www.sqlite.org/c3ref/busy_timeout.html</a>
      */
     public abstract void busy_handler(BusyHandler busyHandler) throws SQLException;
 
@@ -117,7 +117,7 @@ public abstract class DB implements Codes {
      * @return Error description in English.
      * @throws SQLException
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/errcode.html">http://www.sqlite.org/c3ref/errcode.html</a>
+     *     href="https://www.sqlite.org/c3ref/errcode.html">https://www.sqlite.org/c3ref/errcode.html</a>
      */
     abstract String errmsg() throws SQLException;
 
@@ -128,9 +128,9 @@ public abstract class DB implements Codes {
      * @return Compile-time SQLite version information.
      * @throws SQLException
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/libversion.html">http://www.sqlite.org/c3ref/libversion.html</a>
+     *     href="https://www.sqlite.org/c3ref/libversion.html">https://www.sqlite.org/c3ref/libversion.html</a>
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/c_source_id.html">http://www.sqlite.org/c3ref/c_source_id.html</a>
+     *     href="https://www.sqlite.org/c3ref/c_source_id.html">https://www.sqlite.org/c3ref/c_source_id.html</a>
      */
     public abstract String libversion() throws SQLException;
 
@@ -138,7 +138,7 @@ public abstract class DB implements Codes {
      * @return Number of rows that were changed, inserted or deleted by the last SQL statement
      * @throws SQLException
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/changes.html">http://www.sqlite.org/c3ref/changes.html</a>
+     *     href="https://www.sqlite.org/c3ref/changes.html">https://www.sqlite.org/c3ref/changes.html</a>
      */
     public abstract long changes() throws SQLException;
 
@@ -147,7 +147,7 @@ public abstract class DB implements Codes {
      *     database connection was opened.
      * @throws SQLException
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/total_changes.html">http://www.sqlite.org/c3ref/total_changes.html</a>
+     *     href="https://www.sqlite.org/c3ref/total_changes.html">https://www.sqlite.org/c3ref/total_changes.html</a>
      */
     public abstract long total_changes() throws SQLException;
 
@@ -156,10 +156,10 @@ public abstract class DB implements Codes {
      * connections to the same database.
      *
      * @param enable True to enable; false otherwise.
-     * @return <a href="http://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
+     * @return <a href="https://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
      * @throws SQLException
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/enable_shared_cache.html">http://www.sqlite.org/c3ref/enable_shared_cache.html</a>
+     *     href="https://www.sqlite.org/c3ref/enable_shared_cache.html">https://www.sqlite.org/c3ref/enable_shared_cache.html</a>
      * @see org.sqlite.SQLiteErrorCode
      */
     public abstract int shared_cache(boolean enable) throws SQLException;
@@ -168,10 +168,10 @@ public abstract class DB implements Codes {
      * Enables or disables loading of SQLite extensions.
      *
      * @param enable True to enable; false otherwise.
-     * @return <a href="http://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
+     * @return <a href="https://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
      * @throws SQLException
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/load_extension.html">http://www.sqlite.org/c3ref/load_extension.html</a>
+     *     href="https://www.sqlite.org/c3ref/load_extension.html">https://www.sqlite.org/c3ref/load_extension.html</a>
      */
     public abstract int enable_load_extension(boolean enable) throws SQLException;
 
@@ -182,7 +182,7 @@ public abstract class DB implements Codes {
      * @param sql SQL statement to be executed.
      * @throws SQLException
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/exec.html">http://www.sqlite.org/c3ref/exec.html</a>
+     *     href="https://www.sqlite.org/c3ref/exec.html">https://www.sqlite.org/c3ref/exec.html</a>
      */
     public final synchronized void exec(String sql, boolean autoCommit) throws SQLException {
         SafeStmtPtr pointer = prepare(sql);
@@ -207,10 +207,10 @@ public abstract class DB implements Codes {
      *
      * @param file The database.
      * @param openFlags File opening configurations (<a
-     *     href="http://www.sqlite.org/c3ref/c_open_autoproxy.html">http://www.sqlite.org/c3ref/c_open_autoproxy.html</a>)
+     *     href="https://www.sqlite.org/c3ref/c_open_autoproxy.html">https://www.sqlite.org/c3ref/c_open_autoproxy.html</a>)
      * @throws SQLException
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/open.html">http://www.sqlite.org/c3ref/open.html</a>
+     *     href="https://www.sqlite.org/c3ref/open.html">https://www.sqlite.org/c3ref/open.html</a>
      */
     public final synchronized void open(String file, int openFlags) throws SQLException {
         _open(file, openFlags);
@@ -230,7 +230,7 @@ public abstract class DB implements Codes {
      *
      * @throws SQLException
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/close.html">http://www.sqlite.org/c3ref/close.html</a>
+     *     href="https://www.sqlite.org/c3ref/close.html">https://www.sqlite.org/c3ref/close.html</a>
      */
     public final synchronized void close() throws SQLException {
         // finalize any remaining statements before closing db
@@ -252,7 +252,7 @@ public abstract class DB implements Codes {
      * @param stmt The SQL statement to compile.
      * @throws SQLException
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/prepare.html">http://www.sqlite.org/c3ref/prepare.html</a>
+     *     href="https://www.sqlite.org/c3ref/prepare.html">https://www.sqlite.org/c3ref/prepare.html</a>
      */
     public final synchronized void prepare(CoreStatement stmt) throws SQLException {
         if (stmt.sql == null) {
@@ -273,10 +273,10 @@ public abstract class DB implements Codes {
      *
      * @param safePtr the pointer wrapper to remove from internal structures
      * @param ptr the raw pointer to free
-     * @return <a href="http://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
+     * @return <a href="https://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
      * @throws SQLException if finalization fails
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/finalize.html">http://www.sqlite.org/c3ref/finalize.html</a>
+     *     href="https://www.sqlite.org/c3ref/finalize.html">https://www.sqlite.org/c3ref/finalize.html</a>
      */
     public synchronized int finalize(SafeStmtPtr safePtr, long ptr) throws SQLException {
         try {
@@ -291,10 +291,10 @@ public abstract class DB implements Codes {
      *
      * @param filename The database to open.
      * @param openFlags File opening configurations (<a
-     *     href="http://www.sqlite.org/c3ref/c_open_autoproxy.html">http://www.sqlite.org/c3ref/c_open_autoproxy.html</a>)
+     *     href="https://www.sqlite.org/c3ref/c_open_autoproxy.html">https://www.sqlite.org/c3ref/c_open_autoproxy.html</a>)
      * @throws SQLException
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/open.html">http://www.sqlite.org/c3ref/open.html</a>
+     *     href="https://www.sqlite.org/c3ref/open.html">https://www.sqlite.org/c3ref/open.html</a>
      */
     protected abstract void _open(String filename, int openFlags) throws SQLException;
 
@@ -303,7 +303,7 @@ public abstract class DB implements Codes {
      *
      * @throws SQLException
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/close.html">http://www.sqlite.org/c3ref/close.html</a>
+     *     href="https://www.sqlite.org/c3ref/close.html">https://www.sqlite.org/c3ref/close.html</a>
      */
     protected abstract void _close() throws SQLException;
 
@@ -311,10 +311,10 @@ public abstract class DB implements Codes {
      * Complies, evaluates, executes and commits an SQL statement.
      *
      * @param sql An SQL statement.
-     * @return <a href="http://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
+     * @return <a href="https://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
      * @throws SQLException
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/exec.html">http://www.sqlite.org/c3ref/exec.html</a>
+     *     href="https://www.sqlite.org/c3ref/exec.html">https://www.sqlite.org/c3ref/exec.html</a>
      */
     public abstract int _exec(String sql) throws SQLException;
 
@@ -322,10 +322,10 @@ public abstract class DB implements Codes {
      * Complies an SQL statement.
      *
      * @param sql An SQL statement.
-     * @return <a href="http://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
+     * @return <a href="https://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
      * @throws SQLException
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/prepare.html">http://www.sqlite.org/c3ref/prepare.html</a>
+     *     href="https://www.sqlite.org/c3ref/prepare.html">https://www.sqlite.org/c3ref/prepare.html</a>
      */
     protected abstract SafeStmtPtr prepare(String sql) throws SQLException;
 
@@ -333,10 +333,10 @@ public abstract class DB implements Codes {
      * Destroys a prepared statement.
      *
      * @param stmt Pointer to the statement pointer.
-     * @return <a href="http://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
+     * @return <a href="https://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
      * @throws SQLException
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/finalize.html">http://www.sqlite.org/c3ref/finalize.html</a>
+     *     href="https://www.sqlite.org/c3ref/finalize.html">https://www.sqlite.org/c3ref/finalize.html</a>
      */
     protected abstract int finalize(long stmt) throws SQLException;
 
@@ -344,10 +344,10 @@ public abstract class DB implements Codes {
      * Evaluates a statement.
      *
      * @param stmt Pointer to the statement.
-     * @return <a href="http://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
+     * @return <a href="https://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
      * @throws SQLException
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/step.html">http://www.sqlite.org/c3ref/step.html</a>
+     *     href="https://www.sqlite.org/c3ref/step.html">https://www.sqlite.org/c3ref/step.html</a>
      */
     public abstract int step(long stmt) throws SQLException;
 
@@ -355,10 +355,10 @@ public abstract class DB implements Codes {
      * Sets a prepared statement object back to its initial state, ready to be re-executed.
      *
      * @param stmt Pointer to the statement.
-     * @return <a href="http://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
+     * @return <a href="https://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
      * @throws SQLException
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/reset.html">http://www.sqlite.org/c3ref/reset.html</a>
+     *     href="https://www.sqlite.org/c3ref/reset.html">https://www.sqlite.org/c3ref/reset.html</a>
      */
     public abstract int reset(long stmt) throws SQLException;
 
@@ -366,10 +366,10 @@ public abstract class DB implements Codes {
      * Reset all bindings on a prepared statement (reset all host parameters to NULL).
      *
      * @param stmt Pointer to the statement.
-     * @return <a href="http://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
+     * @return <a href="https://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
      * @throws SQLException
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/clear_bindings.html">http://www.sqlite.org/c3ref/clear_bindings.html</a>
+     *     href="https://www.sqlite.org/c3ref/clear_bindings.html">https://www.sqlite.org/c3ref/clear_bindings.html</a>
      */
     public abstract int clear_bindings(long stmt) throws SQLException; // TODO remove?
 
@@ -378,7 +378,7 @@ public abstract class DB implements Codes {
      * @return Number of parameters in a prepared SQL.
      * @throws SQLException
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/bind_parameter_count.html">http://www.sqlite.org/c3ref/bind_parameter_count.html</a>
+     *     href="https://www.sqlite.org/c3ref/bind_parameter_count.html">https://www.sqlite.org/c3ref/bind_parameter_count.html</a>
      */
     abstract int bind_parameter_count(long stmt) throws SQLException;
 
@@ -387,7 +387,7 @@ public abstract class DB implements Codes {
      * @return Number of columns in the result set returned by the prepared statement.
      * @throws SQLException
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/column_count.html">http://www.sqlite.org/c3ref/column_count.html</a>
+     *     href="https://www.sqlite.org/c3ref/column_count.html">https://www.sqlite.org/c3ref/column_count.html</a>
      */
     public abstract int column_count(long stmt) throws SQLException;
 
@@ -397,7 +397,7 @@ public abstract class DB implements Codes {
      * @return Datatype code for the initial data type of the result column.
      * @throws SQLException
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/column_blob.html">http://www.sqlite.org/c3ref/column_blob.html</a>
+     *     href="https://www.sqlite.org/c3ref/column_blob.html">https://www.sqlite.org/c3ref/column_blob.html</a>
      */
     public abstract int column_type(long stmt, int col) throws SQLException;
 
@@ -407,7 +407,7 @@ public abstract class DB implements Codes {
      * @return Declared type of the table column for prepared statement.
      * @throws SQLException
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/column_decltype.html">http://www.sqlite.org/c3ref/column_decltype.html</a>
+     *     href="https://www.sqlite.org/c3ref/column_decltype.html">https://www.sqlite.org/c3ref/column_decltype.html</a>
      */
     public abstract String column_decltype(long stmt, int col) throws SQLException;
 
@@ -417,7 +417,7 @@ public abstract class DB implements Codes {
      * @return Original text of column name which is the declared in the CREATE TABLE statement.
      * @throws SQLException
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/column_database_name.html">http://www.sqlite.org/c3ref/column_database_name.html</a>
+     *     href="https://www.sqlite.org/c3ref/column_database_name.html">https://www.sqlite.org/c3ref/column_database_name.html</a>
      */
     public abstract String column_table_name(long stmt, int col) throws SQLException;
 
@@ -427,7 +427,7 @@ public abstract class DB implements Codes {
      * @return Name assigned to a particular column in the result set of a SELECT statement.
      * @throws SQLException
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/column_name.html">http://www.sqlite.org/c3ref/column_name.html</a>
+     *     href="https://www.sqlite.org/c3ref/column_name.html">https://www.sqlite.org/c3ref/column_name.html</a>
      */
     public abstract String column_name(long stmt, int col) throws SQLException;
 
@@ -437,7 +437,7 @@ public abstract class DB implements Codes {
      * @return Value of the column as text data type in the result set of a SELECT statement.
      * @throws SQLException
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/column_blob.html">http://www.sqlite.org/c3ref/column_blob.html</a>
+     *     href="https://www.sqlite.org/c3ref/column_blob.html">https://www.sqlite.org/c3ref/column_blob.html</a>
      */
     public abstract String column_text(long stmt, int col) throws SQLException;
 
@@ -447,7 +447,7 @@ public abstract class DB implements Codes {
      * @return BLOB value of the column in the result set of a SELECT statement
      * @throws SQLException
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/column_blob.html">http://www.sqlite.org/c3ref/column_blob.html</a>
+     *     href="https://www.sqlite.org/c3ref/column_blob.html">https://www.sqlite.org/c3ref/column_blob.html</a>
      */
     public abstract byte[] column_blob(long stmt, int col) throws SQLException;
 
@@ -457,7 +457,7 @@ public abstract class DB implements Codes {
      * @return DOUBLE value of the column in the result set of a SELECT statement
      * @throws SQLException
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/column_blob.html">http://www.sqlite.org/c3ref/column_blob.html</a>
+     *     href="https://www.sqlite.org/c3ref/column_blob.html">https://www.sqlite.org/c3ref/column_blob.html</a>
      */
     public abstract double column_double(long stmt, int col) throws SQLException;
 
@@ -467,7 +467,7 @@ public abstract class DB implements Codes {
      * @return LONG value of the column in the result set of a SELECT statement.
      * @throws SQLException
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/column_blob.html">http://www.sqlite.org/c3ref/column_blob.html</a>
+     *     href="https://www.sqlite.org/c3ref/column_blob.html">https://www.sqlite.org/c3ref/column_blob.html</a>
      */
     public abstract long column_long(long stmt, int col) throws SQLException;
 
@@ -477,7 +477,7 @@ public abstract class DB implements Codes {
      * @return INT value of column in the result set of a SELECT statement.
      * @throws SQLException
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/column_blob.html">http://www.sqlite.org/c3ref/column_blob.html</a>
+     *     href="https://www.sqlite.org/c3ref/column_blob.html">https://www.sqlite.org/c3ref/column_blob.html</a>
      */
     public abstract int column_int(long stmt, int col) throws SQLException;
 
@@ -487,7 +487,7 @@ public abstract class DB implements Codes {
      *
      * @param stmt Pointer to the statement.
      * @param pos The index of the SQL parameter to be set to NULL.
-     * @return <a href="http://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
+     * @return <a href="https://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
      * @throws SQLException
      */
     abstract int bind_null(long stmt, int pos) throws SQLException;
@@ -499,10 +499,10 @@ public abstract class DB implements Codes {
      * @param stmt Pointer to the statement.
      * @param pos The index of the SQL parameter to be set.
      * @param v Value to bind to the parameter.
-     * @return <a href="http://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
+     * @return <a href="https://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
      * @throws SQLException
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/bind_blob.html">http://www.sqlite.org/c3ref/bind_blob.html</a>
+     *     href="https://www.sqlite.org/c3ref/bind_blob.html">https://www.sqlite.org/c3ref/bind_blob.html</a>
      */
     abstract int bind_int(long stmt, int pos, int v) throws SQLException;
 
@@ -513,10 +513,10 @@ public abstract class DB implements Codes {
      * @param stmt Pointer to the statement.
      * @param pos The index of the SQL parameter to be set.
      * @param v Value to bind to the parameter.
-     * @return <a href="http://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
+     * @return <a href="https://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
      * @throws SQLException
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/bind_blob.html">http://www.sqlite.org/c3ref/bind_blob.html</a>
+     *     href="https://www.sqlite.org/c3ref/bind_blob.html">https://www.sqlite.org/c3ref/bind_blob.html</a>
      */
     abstract int bind_long(long stmt, int pos, long v) throws SQLException;
 
@@ -527,10 +527,10 @@ public abstract class DB implements Codes {
      * @param stmt Pointer to the statement.
      * @param pos Index of the SQL parameter to be set.
      * @param v Value to bind to the parameter.
-     * @return <a href="http://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
+     * @return <a href="https://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
      * @throws SQLException
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/bind_blob.html">http://www.sqlite.org/c3ref/bind_blob.html</a>
+     *     href="https://www.sqlite.org/c3ref/bind_blob.html">https://www.sqlite.org/c3ref/bind_blob.html</a>
      */
     abstract int bind_double(long stmt, int pos, double v) throws SQLException;
 
@@ -541,10 +541,10 @@ public abstract class DB implements Codes {
      * @param stmt Pointer to the statement.
      * @param pos Index of the SQL parameter to be set.
      * @param v value to bind to the parameter.
-     * @return <a href="http://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
+     * @return <a href="https://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
      * @throws SQLException
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/bind_blob.html">http://www.sqlite.org/c3ref/bind_blob.html</a>
+     *     href="https://www.sqlite.org/c3ref/bind_blob.html">https://www.sqlite.org/c3ref/bind_blob.html</a>
      */
     abstract int bind_text(long stmt, int pos, String v) throws SQLException;
 
@@ -555,10 +555,10 @@ public abstract class DB implements Codes {
      * @param stmt Pointer to the statement.
      * @param pos Index of the SQL parameter to be set.
      * @param v Value to bind to the parameter.
-     * @return <a href="http://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
+     * @return <a href="https://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
      * @throws SQLException
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/bind_blob.html">http://www.sqlite.org/c3ref/bind_blob.html</a>
+     *     href="https://www.sqlite.org/c3ref/bind_blob.html">https://www.sqlite.org/c3ref/bind_blob.html</a>
      */
     abstract int bind_blob(long stmt, int pos, byte[] v) throws SQLException;
 
@@ -568,7 +568,7 @@ public abstract class DB implements Codes {
      * @param context Pointer to the SQLite database context.
      * @throws SQLException
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/result_blob.html">http://www.sqlite.org/c3ref/result_blob.html</a>
+     *     href="https://www.sqlite.org/c3ref/result_blob.html">https://www.sqlite.org/c3ref/result_blob.html</a>
      */
     public abstract void result_null(long context) throws SQLException;
 
@@ -580,7 +580,7 @@ public abstract class DB implements Codes {
      * @param val Result value of an SQL function.
      * @throws SQLException
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/result_blob.html">http://www.sqlite.org/c3ref/result_blob.html</a>
+     *     href="https://www.sqlite.org/c3ref/result_blob.html">https://www.sqlite.org/c3ref/result_blob.html</a>
      */
     public abstract void result_text(long context, String val) throws SQLException;
 
@@ -592,7 +592,7 @@ public abstract class DB implements Codes {
      * @param val Result value of an SQL function.
      * @throws SQLException
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/result_blob.html">http://www.sqlite.org/c3ref/result_blob.html</a>
+     *     href="https://www.sqlite.org/c3ref/result_blob.html">https://www.sqlite.org/c3ref/result_blob.html</a>
      */
     public abstract void result_blob(long context, byte[] val) throws SQLException;
 
@@ -604,7 +604,7 @@ public abstract class DB implements Codes {
      * @param val Result value of an SQL function.
      * @throws SQLException
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/result_blob.html">http://www.sqlite.org/c3ref/result_blob.html</a>
+     *     href="https://www.sqlite.org/c3ref/result_blob.html">https://www.sqlite.org/c3ref/result_blob.html</a>
      */
     public abstract void result_double(long context, double val) throws SQLException;
 
@@ -616,7 +616,7 @@ public abstract class DB implements Codes {
      * @param val Result value of an SQL function.
      * @throws SQLException
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/result_blob.html">http://www.sqlite.org/c3ref/result_blob.html</a>
+     *     href="https://www.sqlite.org/c3ref/result_blob.html">https://www.sqlite.org/c3ref/result_blob.html</a>
      */
     public abstract void result_long(long context, long val) throws SQLException;
 
@@ -628,7 +628,7 @@ public abstract class DB implements Codes {
      * @param val Result value of an SQL function.
      * @throws SQLException
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/result_blob.html">http://www.sqlite.org/c3ref/result_blob.html</a>
+     *     href="https://www.sqlite.org/c3ref/result_blob.html">https://www.sqlite.org/c3ref/result_blob.html</a>
      */
     public abstract void result_int(long context, int val) throws SQLException;
 
@@ -640,7 +640,7 @@ public abstract class DB implements Codes {
      * @param err Error result of an SQL function.
      * @throws SQLException
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/result_blob.html">http://www.sqlite.org/c3ref/result_blob.html</a>
+     *     href="https://www.sqlite.org/c3ref/result_blob.html">https://www.sqlite.org/c3ref/result_blob.html</a>
      */
     public abstract void result_error(long context, String err) throws SQLException;
 
@@ -650,7 +650,7 @@ public abstract class DB implements Codes {
      * @return Parameter value of the given SQLite function or aggregate in text data type.
      * @throws SQLException
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/value_blob.html">http://www.sqlite.org/c3ref/value_blob.html</a>
+     *     href="https://www.sqlite.org/c3ref/value_blob.html">https://www.sqlite.org/c3ref/value_blob.html</a>
      */
     public abstract String value_text(Function f, int arg) throws SQLException;
 
@@ -660,7 +660,7 @@ public abstract class DB implements Codes {
      * @return Parameter value of the given SQLite function or aggregate in blob data type.
      * @throws SQLException
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/value_blob.html">http://www.sqlite.org/c3ref/value_blob.html</a>
+     *     href="https://www.sqlite.org/c3ref/value_blob.html">https://www.sqlite.org/c3ref/value_blob.html</a>
      */
     public abstract byte[] value_blob(Function f, int arg) throws SQLException;
 
@@ -670,7 +670,7 @@ public abstract class DB implements Codes {
      * @return Parameter value of the given SQLite function or aggregate in double data type
      * @throws SQLException
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/value_blob.html">http://www.sqlite.org/c3ref/value_blob.html</a>
+     *     href="https://www.sqlite.org/c3ref/value_blob.html">https://www.sqlite.org/c3ref/value_blob.html</a>
      */
     public abstract double value_double(Function f, int arg) throws SQLException;
 
@@ -680,7 +680,7 @@ public abstract class DB implements Codes {
      * @return Parameter value of the given SQLite function or aggregate in long data type.
      * @throws SQLException
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/value_blob.html">http://www.sqlite.org/c3ref/value_blob.html</a>
+     *     href="https://www.sqlite.org/c3ref/value_blob.html">https://www.sqlite.org/c3ref/value_blob.html</a>
      */
     public abstract long value_long(Function f, int arg) throws SQLException;
 
@@ -693,7 +693,7 @@ public abstract class DB implements Codes {
      * @return Parameter value of the given SQLite function or aggregate.
      * @throws SQLException
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/value_blob.html">http://www.sqlite.org/c3ref/value_blob.html</a>
+     *     href="https://www.sqlite.org/c3ref/value_blob.html">https://www.sqlite.org/c3ref/value_blob.html</a>
      */
     public abstract int value_int(Function f, int arg) throws SQLException;
 
@@ -703,7 +703,7 @@ public abstract class DB implements Codes {
      * @return Parameter datatype of the function or aggregate in int data type.
      * @throws SQLException
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/value_blob.html">http://www.sqlite.org/c3ref/value_blob.html</a>
+     *     href="https://www.sqlite.org/c3ref/value_blob.html">https://www.sqlite.org/c3ref/value_blob.html</a>
      */
     public abstract int value_type(Function f, int arg) throws SQLException;
 
@@ -714,10 +714,10 @@ public abstract class DB implements Codes {
      * @param f SQLite function object.
      * @param flags Extra flags to use when creating the function, such as {@link
      *     Function#FLAG_DETERMINISTIC}
-     * @return <a href="http://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
+     * @return <a href="https://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
      * @throws SQLException
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/create_function.html">http://www.sqlite.org/c3ref/create_function.html</a>
+     *     href="https://www.sqlite.org/c3ref/create_function.html">https://www.sqlite.org/c3ref/create_function.html</a>
      */
     public abstract int create_function(String name, Function f, int nArgs, int flags)
             throws SQLException;
@@ -726,7 +726,7 @@ public abstract class DB implements Codes {
      * De-registers a user defined function
      *
      * @param name Name of the function to de-registered.
-     * @return <a href="http://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
+     * @return <a href="https://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
      * @throws SQLException
      */
     public abstract int destroy_function(String name) throws SQLException;
@@ -756,7 +756,7 @@ public abstract class DB implements Codes {
      * @param dbName Database name to be backed up.
      * @param destFileName Target backup file name.
      * @param observer ProgressObserver object.
-     * @return <a href="http://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
+     * @return <a href="https://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
      * @throws SQLException
      */
     public abstract int backup(String dbName, String destFileName, ProgressObserver observer)
@@ -772,7 +772,7 @@ public abstract class DB implements Codes {
      *     failing
      * @param pagesPerStep the number of pages to copy in each sqlite3_backup_step. If this is
      *     negative, the entire DB is copied at once.
-     * @return <a href="http://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
+     * @return <a href="https://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
      * @throws SQLException
      */
     public abstract int backup(
@@ -788,7 +788,7 @@ public abstract class DB implements Codes {
      * @param dbName Database name for restoring data.
      * @param sourceFileName Source file name.
      * @param observer ProgressObserver object.
-     * @return <a href="http://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
+     * @return <a href="https://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
      * @throws SQLException
      */
     public abstract int restore(String dbName, String sourceFileName, ProgressObserver observer)
@@ -804,7 +804,7 @@ public abstract class DB implements Codes {
      *     failing
      * @param pagesPerStep the number of pages to copy in each sqlite3_backup_step. If this is
      *     negative, the entire DB is copied at once.
-     * @return <a href="http://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
+     * @return <a href="https://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
      * @throws SQLException
      */
     public abstract int restore(
@@ -872,10 +872,10 @@ public abstract class DB implements Codes {
      * @param stmt Pointer to the statement.
      * @param pos Index of the SQL parameter to be set to NULL.
      * @param v Value to bind to the parameter.
-     * @return <a href="http://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
+     * @return <a href="https://www.sqlite.org/c3ref/c_abort.html">Result Codes</a>
      * @throws SQLException
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/bind_blob.html">http://www.sqlite.org/c3ref/bind_blob.html</a>
+     *     href="https://www.sqlite.org/c3ref/bind_blob.html">https://www.sqlite.org/c3ref/bind_blob.html</a>
      */
     final synchronized int sqlbind(long stmt, int pos, Object v) throws SQLException {
         pos++;
@@ -963,7 +963,7 @@ public abstract class DB implements Codes {
 
     /**
      * @see <a
-     *     href="http://www.sqlite.org/c_interface.html#sqlite_exec">http://www.sqlite.org/c_interface.html#sqlite_exec</a>
+     *     href="https://www.sqlite.org/c_interface.html#sqlite_exec">https://www.sqlite.org/c_interface.html#sqlite_exec</a>
      * @param stmt Stmt object.
      * @param vals Array of parameter values.
      * @return True if a row of ResultSet is ready; false otherwise.
@@ -1021,7 +1021,7 @@ public abstract class DB implements Codes {
      * @return True if a row of ResultSet is ready; false otherwise.
      * @throws SQLException
      * @see <a
-     *     href="http://www.sqlite.org/c3ref/exec.html">http://www.sqlite.org/c3ref/exec.html</a>
+     *     href="https://www.sqlite.org/c3ref/exec.html">https://www.sqlite.org/c3ref/exec.html</a>
      */
     final synchronized boolean execute(String sql, boolean autoCommit) throws SQLException {
         int statusCode = _exec(sql);

--- a/src/main/java/org/sqlite/jdbc3/JDBC3Connection.java
+++ b/src/main/java/org/sqlite/jdbc3/JDBC3Connection.java
@@ -237,7 +237,7 @@ public abstract class JDBC3Connection extends SQLiteConnection {
             // when a SAVEPOINT is the outermost savepoint and not
             // with a BEGIN...COMMIT then the behavior is the same
             // as BEGIN DEFERRED TRANSACTION
-            // http://www.sqlite.org/lang_savepoint.html
+            // https://www.sqlite.org/lang_savepoint.html
             getConnectionConfig().setAutoCommit(false);
         }
         Savepoint sp = new JDBC3Savepoint(savePoint.incrementAndGet());
@@ -252,7 +252,7 @@ public abstract class JDBC3Connection extends SQLiteConnection {
             // when a SAVEPOINT is the outermost savepoint and not
             // with a BEGIN...COMMIT then the behavior is the same
             // as BEGIN DEFERRED TRANSACTION
-            // http://www.sqlite.org/lang_savepoint.html
+            // https://www.sqlite.org/lang_savepoint.html
             getConnectionConfig().setAutoCommit(false);
         }
         Savepoint sp = new JDBC3Savepoint(savePoint.incrementAndGet(), name);

--- a/src/main/java/org/sqlite/jdbc3/JDBC3DatabaseMetaData.java
+++ b/src/main/java/org/sqlite/jdbc3/JDBC3DatabaseMetaData.java
@@ -262,7 +262,7 @@ public abstract class JDBC3DatabaseMetaData extends org.sqlite.core.CoreDatabase
 
     /**
      * @see java.sql.DatabaseMetaData#getSQLKeywords()
-     * @see <a href="https://sqlite.org/lang_keywords.html">SQLite Keywords</a>
+     * @see <a href="https://www.sqlite.org/lang_keywords.html">SQLite Keywords</a>
      */
     public String getSQLKeywords() {
         return "ABORT,ACTION,AFTER,ANALYZE,ATTACH,AUTOINCREMENT,BEFORE,"
@@ -1002,7 +1002,7 @@ public abstract class JDBC3DatabaseMetaData extends org.sqlite.core.CoreDatabase
 
                         /*
                          * improved column types
-                         * ref http://www.sqlite.org/datatype3.html - 2.1 Determination Of Column Affinity
+                         * ref https://www.sqlite.org/datatype3.html - 2.1 Determination Of Column Affinity
                          * plus some degree of artistic-license applied
                          */
                         colType = colType == null ? "TEXT" : colType.toUpperCase();
@@ -2216,7 +2216,7 @@ public abstract class JDBC3DatabaseMetaData extends org.sqlite.core.CoreDatabase
     }
 
     /**
-     * Follow rules in <a href="https://sqlite.org/lang_keywords.html">SQLite Keywords</a>
+     * Follow rules in <a href="https://www.sqlite.org/lang_keywords.html">SQLite Keywords</a>
      *
      * @param name Identifier name
      * @return Unquoted identifier

--- a/src/test/java/org/sqlite/JSON1Test.java
+++ b/src/test/java/org/sqlite/JSON1Test.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests the JSON1 extension using the examples listed in the documentation.
  *
- * @see <a href="http://sqlite.org/json1.html">http://sqlite.org/json1.html</a>
+ * @see <a href="https://www.sqlite.org/json1.html">https://www.sqlite.org/json1.html</a>
  */
 public class JSON1Test {
 


### PR DESCRIPTION
I think the more `https` the better.

1. Replaced `http://www.sqlite.org` with `https://www.sqlite.org`
2. Replaced `http://sqlite.org` with `https://www.sqlite.org`
3. Replaced `https://sqlite.org` with `https://www.sqlite.org`
4. Changed another http to https in Readme