### PR TITLE
remove temp files post test execution

### DIFF
--- a/src/main/java/org/sqlite/SQLiteConnection.java
+++ b/src/main/java/org/sqlite/SQLiteConnection.java
@@ -6,6 +6,7 @@ import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.net.URLConnection;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.sql.Connection;
@@ -330,7 +331,10 @@ public abstract class SQLiteConnection implements Connection {
             //            }
         }
 
-        try (InputStream reader = resourceAddr.openStream()) {
+        URLConnection conn = resourceAddr.openConnection();
+        // Disable caches to avoid keeping unnecessary file references after the single-use copy
+        conn.setUseCaches(false);
+        try (InputStream reader = conn.getInputStream()) {
             Files.copy(reader, dbFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
             return dbFile;
         }

--- a/src/test/java/org/sqlite/ConnectionTest.java
+++ b/src/test/java/org/sqlite/ConnectionTest.java
@@ -1,20 +1,12 @@
 package org.sqlite;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.*;
 
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.ResultSetMetaData;
-import java.sql.SQLException;
-import java.sql.Statement;
+import java.sql.*;
 import java.util.ArrayList;
 import java.util.Properties;
 import java.util.concurrent.ExecutionException;
@@ -22,14 +14,17 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.sqlite.SQLiteConfig.JournalMode;
 import org.sqlite.SQLiteConfig.Pragma;
 import org.sqlite.SQLiteConfig.SynchronousMode;
 
 /**
- * These tests check whether access to files is woring correctly and some Connection.close() cases.
+ * These tests check whether access to files is working correctly and some Connection.close() cases.
  */
 public class ConnectionTest {
+
+    @TempDir static File tempDir;
 
     @Test
     public void isValid() throws SQLException {
@@ -226,12 +221,8 @@ public class ConnectionTest {
 
     public static File copyToTemp(String fileName) throws IOException {
         InputStream in = ConnectionTest.class.getResourceAsStream(fileName);
-        File dir = new File("target");
-        if (!dir.exists()) {
-            dir.mkdirs();
-        }
 
-        File tmp = File.createTempFile(fileName, "", new File("target"));
+        File tmp = File.createTempFile(fileName, "", tempDir);
         tmp.deleteOnExit();
         FileOutputStream out = new FileOutputStream(tmp);
 
@@ -280,6 +271,10 @@ public class ConnectionTest {
         assertThat(rs.getInt(1)).isEqualTo(200);
         rs.close();
         stmt4.close();
+
+        conn1.close();
+        conn2.close();
+        conn3.close();
         conn4.close();
     }
 
@@ -325,6 +320,7 @@ public class ConnectionTest {
                 .isThrownBy(() -> stat.executeUpdate("ATTACH DATABASE attach_test.db AS attachDb"));
 
         stat.close();
+        conn.close();
     }
 
     @Test

--- a/src/test/java/org/sqlite/ErrorMessageTest.java
+++ b/src/test/java/org/sqlite/ErrorMessageTest.java
@@ -12,62 +12,60 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledInNativeImage;
+import org.junit.jupiter.api.io.TempDir;
 import org.sqlite.core.DB;
 
 @DisabledInNativeImage // assertj Assumptions do not work in native-image tests
 public class ErrorMessageTest {
+    @TempDir File tempDir;
+
     @Test
     public void moved() throws SQLException, IOException {
-        File from = File.createTempFile("error-message-test-moved-from", ".sqlite");
-        from.deleteOnExit();
+        File from = File.createTempFile("error-message-test-moved-from", ".sqlite", tempDir);
 
-        Connection conn = DriverManager.getConnection("jdbc:sqlite:" + from.getAbsolutePath());
-        Statement stmt = conn.createStatement();
-        stmt.executeUpdate("create table sample(id, name)");
-        stmt.executeUpdate("insert into sample values(1, 'foo')");
+        try (Connection conn =
+                        DriverManager.getConnection("jdbc:sqlite:" + from.getAbsolutePath());
+                Statement stmt = conn.createStatement()) {
+            stmt.executeUpdate("create table sample(id, name)");
+            stmt.executeUpdate("insert into sample values(1, 'foo')");
 
-        File to = File.createTempFile("error-message-test-moved-from", ".sqlite");
-        assumeThat(to.delete()).isTrue();
-        assumeThat(from.renameTo(to)).isTrue();
+            File to = File.createTempFile("error-message-test-moved-from", ".sqlite", tempDir);
+            assumeThat(to.delete()).isTrue();
+            assumeThat(from.renameTo(to)).isTrue();
 
-        assertThatThrownBy(() -> stmt.executeUpdate("insert into sample values(2, 'bar')"))
-                .isInstanceOf(SQLException.class)
-                .hasMessageStartingWith("[SQLITE_READONLY_DBMOVED]");
-
-        stmt.close();
-        conn.close();
+            assertThatThrownBy(() -> stmt.executeUpdate("insert into sample values(2, 'bar')"))
+                    .isInstanceOf(SQLException.class)
+                    .hasMessageStartingWith("[SQLITE_READONLY_DBMOVED]");
+        }
     }
 
     @Test
     public void writeProtected() throws SQLException, IOException {
-        File file = File.createTempFile("error-message-test-write-protected", ".sqlite");
-        file.deleteOnExit();
+        File file = File.createTempFile("error-message-test-write-protected", ".sqlite", tempDir);
 
-        Connection conn = DriverManager.getConnection("jdbc:sqlite:" + file.getAbsolutePath());
-        Statement stmt = conn.createStatement();
-        stmt.executeUpdate("create table sample(id, name)");
-        stmt.executeUpdate("insert into sample values(1, 'foo')");
-        stmt.close();
-        conn.close();
+        try (Connection conn =
+                        DriverManager.getConnection("jdbc:sqlite:" + file.getAbsolutePath());
+                Statement stmt = conn.createStatement()) {
+            stmt.executeUpdate("create table sample(id, name)");
+            stmt.executeUpdate("insert into sample values(1, 'foo')");
+        }
 
         assumeThat(file.setReadOnly()).isTrue();
 
-        conn = DriverManager.getConnection("jdbc:sqlite:" + file.getAbsolutePath());
-        stmt = conn.createStatement();
-        Statement finalStmt = stmt;
-        assertThatThrownBy(() -> finalStmt.executeUpdate("insert into sample values(2, 'bar')"))
-                .isInstanceOf(SQLException.class)
-                .hasMessageStartingWith("[SQLITE_READONLY]");
-        stmt.close();
-        conn.close();
+        try (Connection conn =
+                        DriverManager.getConnection("jdbc:sqlite:" + file.getAbsolutePath());
+                Statement stmt = conn.createStatement()) {
+            assertThatThrownBy(() -> stmt.executeUpdate("insert into sample values(2, 'bar')"))
+                    .isInstanceOf(SQLException.class)
+                    .hasMessageStartingWith("[SQLITE_READONLY]");
+        }
     }
 
     @Test
     public void cantOpenDir() throws IOException {
-        File dir = File.createTempFile("error-message-test-cant-open-dir", "");
+        File dir = File.createTempFile("error-message-test-cant-open-dir", "", tempDir);
         assumeThat(dir.delete()).isTrue();
         assumeThat(dir.mkdir()).isTrue();
-        dir.deleteOnExit();
 
         assertThatThrownBy(
                         () -> DriverManager.getConnection("jdbc:sqlite:" + dir.getAbsolutePath()))
@@ -78,31 +76,29 @@ public class ErrorMessageTest {
     @Test
     public void shouldUsePlainErrorCodeAsVendorCodeAndExtendedAsResultCode()
             throws SQLException, IOException {
-        File from = File.createTempFile("error-message-test-plain-1", ".sqlite");
-        from.deleteOnExit();
+        File from = File.createTempFile("error-message-test-plain-1", ".sqlite", tempDir);
 
-        Connection conn = DriverManager.getConnection("jdbc:sqlite:" + from.getAbsolutePath());
-        Statement stmt = conn.createStatement();
-        stmt.executeUpdate("create table sample(id, name)");
-        stmt.executeUpdate("insert into sample values(1, 'foo')");
+        try (Connection conn =
+                        DriverManager.getConnection("jdbc:sqlite:" + from.getAbsolutePath());
+                Statement stmt = conn.createStatement()) {
+            stmt.executeUpdate("create table sample(id, name)");
+            stmt.executeUpdate("insert into sample values(1, 'foo')");
 
-        File to = File.createTempFile("error-message-test-plain-2", ".sqlite");
-        assumeThat(to.delete()).isTrue();
-        assumeThat(from.renameTo(to)).isTrue();
+            File to = File.createTempFile("error-message-test-plain-2", ".sqlite", tempDir);
+            assumeThat(to.delete()).isTrue();
+            assumeThat(from.renameTo(to)).isTrue();
 
-        assertThatThrownBy(() -> stmt.executeUpdate("insert into sample values(2, 'bar')"))
-                .isInstanceOfSatisfying(
-                        SQLiteException.class,
-                        (ex) -> {
-                            assertThat(SQLiteErrorCode.getErrorCode(ex.getErrorCode()))
-                                    .isEqualTo(SQLiteErrorCode.SQLITE_READONLY);
-                            assertThat(ex.getResultCode())
-                                    .isEqualTo(SQLiteErrorCode.SQLITE_READONLY_DBMOVED);
-                        })
-                .hasMessageStartingWith("[SQLITE_READONLY_DBMOVED]");
-
-        stmt.close();
-        conn.close();
+            assertThatThrownBy(() -> stmt.executeUpdate("insert into sample values(2, 'bar')"))
+                    .isInstanceOfSatisfying(
+                            SQLiteException.class,
+                            (ex) -> {
+                                assertThat(SQLiteErrorCode.getErrorCode(ex.getErrorCode()))
+                                        .isEqualTo(SQLiteErrorCode.SQLITE_READONLY);
+                                assertThat(ex.getResultCode())
+                                        .isEqualTo(SQLiteErrorCode.SQLITE_READONLY_DBMOVED);
+                            })
+                    .hasMessageStartingWith("[SQLITE_READONLY_DBMOVED]");
+        }
     }
 
     @Test

--- a/src/test/java/org/sqlite/JDBCTest.java
+++ b/src/test/java/org/sqlite/JDBCTest.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class JDBCTest {
     @Test
@@ -182,9 +183,9 @@ public class JDBCTest {
     void name() {}
 
     @Test
-    public void jdbcHammer() throws Exception {
+    public void jdbcHammer(@TempDir File tempDir) throws Exception {
         final SQLiteDataSource dataSource = createDatasourceWithExplicitReadonly();
-        File tempFile = File.createTempFile("myTestDB", ".db");
+        File tempFile = File.createTempFile("myTestDB", ".db", tempDir);
         dataSource.setUrl("jdbc:sqlite:" + tempFile.getAbsolutePath());
         try (Connection connection = dataSource.getConnection()) {
             connection.setAutoCommit(false);

--- a/src/test/java/org/sqlite/ListenerTest.java
+++ b/src/test/java/org/sqlite/ListenerTest.java
@@ -11,8 +11,10 @@ import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.sqlite.core.DB;
 import org.sqlite.core.NativeDBHelper;
 
@@ -21,9 +23,8 @@ public class ListenerTest {
     private SQLiteConnection connectionOne, connectionTwo;
 
     @BeforeEach
-    public void connect() throws Exception {
-        File tmpFile = File.createTempFile("test-listeners", ".db");
-        tmpFile.deleteOnExit();
+    public void connect(@TempDir File tempDir) throws Exception {
+        File tmpFile = File.createTempFile("test-listeners", ".db", tempDir);
 
         connectionOne =
                 (SQLiteConnection)
@@ -35,6 +36,12 @@ public class ListenerTest {
         Statement create = connectionOne.createStatement();
         create.execute(
                 "CREATE TABLE IF NOT EXISTS sample (id INTEGER PRIMARY KEY AUTOINCREMENT, description TEXT);");
+    }
+
+    @AfterEach
+    public void close() throws Exception {
+        connectionOne.close();
+        connectionTwo.close();
     }
 
     @Test

--- a/src/test/java/org/sqlite/SQLiteJDBCLoaderTest.java
+++ b/src/test/java/org/sqlite/SQLiteJDBCLoaderTest.java
@@ -27,11 +27,8 @@ package org.sqlite;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
+import java.nio.file.Path;
+import java.sql.*;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -39,6 +36,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class SQLiteJDBCLoaderTest {
 
@@ -110,11 +108,11 @@ public class SQLiteJDBCLoaderTest {
     }
 
     @Test
-    public void test() throws Throwable {
+    public void test(@TempDir Path tmpDir) throws Throwable {
         final AtomicInteger completedThreads = new AtomicInteger(0);
         ExecutorService pool = Executors.newFixedThreadPool(32);
         for (int i = 0; i < 32; i++) {
-            final String connStr = "jdbc:sqlite:target/sample-" + i + ".db";
+            final String connStr = "jdbc:sqlite:" + tmpDir.resolve("sample-" + i + ".db");
             final int sleepMillis = i;
             pool.execute(
                     () -> {
@@ -129,6 +127,7 @@ public class SQLiteJDBCLoaderTest {
                                             // works.
                                             // synchronized (TestSqlite.class) {
                                             Connection conn = DriverManager.getConnection(connStr);
+                                            conn.close();
                                             // }
                                         });
                         completedThreads.incrementAndGet();

--- a/src/test/java/org/sqlite/SavepointTest.java
+++ b/src/test/java/org/sqlite/SavepointTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * These tests assume that Statements and PreparedStatements are working as per normal and test the
@@ -34,9 +35,8 @@ public class SavepointTest {
     }
 
     @BeforeEach
-    public void connect() throws Exception {
-        File tmpFile = File.createTempFile("test-trans", ".db");
-        // tmpFile.deleteOnExit();
+    public void connect(@TempDir File tempDir) throws Exception {
+        File tmpFile = File.createTempFile("test-trans", ".db", tempDir);
 
         Properties prop = new Properties();
         prop.setProperty("shared_cache", "false");


### PR DESCRIPTION
Leverage the built-in JUnit5 `@TempFile` functionality to automatically remove any temp files created in those temp directories.
This avoids leaving files in `java.io.tmpdir` or in the `target` folder. JUnit5 will also fails the test if any of the created files cannot be deleted.
This was mainly caused by tests where database connections were not properly disposed of, but there is one change in `SQLiteConnection` because the `JarURLConnection` keeps an internal cache of the jar files in which the resourcelookup is happening. This caused `ConnectionTest#openJARResource` to fail as it could not delete the jar file.
