### PR TITLE
fix SQLiteConfig keep cached busyTimeout more consistent with busy_timeout pragma

### DIFF
--- a/src/main/java/org/sqlite/SQLiteConfig.java
+++ b/src/main/java/org/sqlite/SQLiteConfig.java
@@ -87,7 +87,8 @@ public class SQLiteConfig {
         // Enable URI filenames
         setOpenMode(SQLiteOpenMode.OPEN_URI);
 
-        setBusyTimeout(Integer.parseInt(pragmaTable.getProperty(Pragma.BUSY_TIMEOUT.pragmaName, "3000")));
+        setBusyTimeout(
+                Integer.parseInt(pragmaTable.getProperty(Pragma.BUSY_TIMEOUT.pragmaName, "3000")));
         this.defaultConnectionConfig = SQLiteConnectionConfig.fromPragmaTable(pragmaTable);
         this.explicitReadOnly =
                 Boolean.parseBoolean(

--- a/src/main/java/org/sqlite/SQLiteConfig.java
+++ b/src/main/java/org/sqlite/SQLiteConfig.java
@@ -54,7 +54,7 @@ public class SQLiteConfig {
     private final Properties pragmaTable;
     private int openModeFlag = 0x00;
 
-    private final int busyTimeout;
+    private int busyTimeout;
     private boolean explicitReadOnly;
 
     private final SQLiteConnectionConfig defaultConnectionConfig;
@@ -87,8 +87,7 @@ public class SQLiteConfig {
         // Enable URI filenames
         setOpenMode(SQLiteOpenMode.OPEN_URI);
 
-        this.busyTimeout =
-                Integer.parseInt(pragmaTable.getProperty(Pragma.BUSY_TIMEOUT.pragmaName, "3000"));
+        setBusyTimeout(Integer.parseInt(pragmaTable.getProperty(Pragma.BUSY_TIMEOUT.pragmaName, "3000")));
         this.defaultConnectionConfig = SQLiteConnectionConfig.fromPragmaTable(pragmaTable);
         this.explicitReadOnly =
                 Boolean.parseBoolean(
@@ -1162,6 +1161,7 @@ public class SQLiteConfig {
     /** @param milliseconds Connect to DB timeout in milliseconds */
     public void setBusyTimeout(int milliseconds) {
         setPragma(Pragma.BUSY_TIMEOUT, Integer.toString(milliseconds));
+        busyTimeout = milliseconds;
     }
 
     public int getBusyTimeout() {

--- a/src/test/java/org/sqlite/SQLiteConfigTest.java
+++ b/src/test/java/org/sqlite/SQLiteConfigTest.java
@@ -25,4 +25,26 @@ public class SQLiteConfigTest {
         assertThat(properties.getProperty(SQLiteConfig.Pragma.DATE_CLASS.getPragmaName()))
                 .isEqualTo(SQLiteConfig.DateClass.REAL.name());
     }
+
+    @Test
+    public void setBusyTimeout() {
+        SQLiteConfig config = new SQLiteConfig();
+
+        // verify the default is set in the pragma table and the cached value
+        assertThat(config.toProperties().getProperty(SQLiteConfig.Pragma.BUSY_TIMEOUT.pragmaName)).isEqualTo("3000");
+        assertThat(config.getBusyTimeout()).isEqualTo(3000);
+
+        // verify that the default is updated in both places
+        config.setBusyTimeout(1234);
+        assertThat(config.toProperties().getProperty(SQLiteConfig.Pragma.BUSY_TIMEOUT.pragmaName)).isEqualTo("1234");
+        assertThat(config.getBusyTimeout()).isEqualTo(1234);
+
+        Properties properties = new Properties();
+        properties.setProperty(SQLiteConfig.Pragma.BUSY_TIMEOUT.pragmaName, "100");
+        config = new SQLiteConfig(properties);
+
+        // verify that we can set an initial value other than the default
+        assertThat(config.toProperties().getProperty(SQLiteConfig.Pragma.BUSY_TIMEOUT.pragmaName)).isEqualTo("100");
+        assertThat(config.getBusyTimeout()).isEqualTo(100);
+    }
 }

--- a/src/test/java/org/sqlite/SQLiteConfigTest.java
+++ b/src/test/java/org/sqlite/SQLiteConfigTest.java
@@ -31,12 +31,14 @@ public class SQLiteConfigTest {
         SQLiteConfig config = new SQLiteConfig();
 
         // verify the default is set in the pragma table and the cached value
-        assertThat(config.toProperties().getProperty(SQLiteConfig.Pragma.BUSY_TIMEOUT.pragmaName)).isEqualTo("3000");
+        assertThat(config.toProperties().getProperty(SQLiteConfig.Pragma.BUSY_TIMEOUT.pragmaName))
+                .isEqualTo("3000");
         assertThat(config.getBusyTimeout()).isEqualTo(3000);
 
         // verify that the default is updated in both places
         config.setBusyTimeout(1234);
-        assertThat(config.toProperties().getProperty(SQLiteConfig.Pragma.BUSY_TIMEOUT.pragmaName)).isEqualTo("1234");
+        assertThat(config.toProperties().getProperty(SQLiteConfig.Pragma.BUSY_TIMEOUT.pragmaName))
+                .isEqualTo("1234");
         assertThat(config.getBusyTimeout()).isEqualTo(1234);
 
         Properties properties = new Properties();
@@ -44,7 +46,8 @@ public class SQLiteConfigTest {
         config = new SQLiteConfig(properties);
 
         // verify that we can set an initial value other than the default
-        assertThat(config.toProperties().getProperty(SQLiteConfig.Pragma.BUSY_TIMEOUT.pragmaName)).isEqualTo("100");
+        assertThat(config.toProperties().getProperty(SQLiteConfig.Pragma.BUSY_TIMEOUT.pragmaName))
+                .isEqualTo("100");
         assertThat(config.getBusyTimeout()).isEqualTo(100);
     }
 }


### PR DESCRIPTION
I noticed while setting up the DataSource that the SQLiteConfig busyTimeout was getting out of synch with the busy_timeout pragma when doing something like the following:

```
final SQLiteDataSource ds = new SQLiteDataSource();
ds.getConfig().setBusyTimeout(2000);
```

This PR fixes this inconsistency. Note that it is still possible to set the pragma value directly and get out of synch, for example:
```
final SQLiteDataSource ds = new SQLiteDataSource();
ds.getConfig().setBusyTimeout(2000);
ds.getConfig().setPragma(Pragma.BUSY_TIMEOUT, "5000");
```

But, at least with this patch, you'd have to go out of your way to get out of synch, and for the normal usage, these values would now be kept in synch.

EDIT: added a second commit with a new test.