### PR TITLE
feat(SQLiteDataSource): add setBusyTimeout

### DIFF
--- a/src/main/java/org/sqlite/SQLiteDataSource.java
+++ b/src/main/java/org/sqlite/SQLiteDataSource.java
@@ -140,6 +140,17 @@ public class SQLiteDataSource implements DataSource {
     }
 
     /**
+     * Sets the amount of time that the connection's busy handler will wait when a table is locked.
+     *
+     * @param milliseconds The number of milliseconds to wait.
+     * @see <a
+     *     href="https://www.sqlite.org/pragma.html#pragma_busy_timeout">https://www.sqlite.org/pragma.html#pragma_busy_timeout</a>
+     */
+    public void setBusyTimeout(int milliseconds) {
+        config.setBusyTimeout(milliseconds);
+    }
+
+    /**
      * Sets the suggested maximum number of database disk pages that SQLite will hold in memory at
      * once per open database file.
      *

--- a/src/test/java/org/sqlite/SQLiteDataSourceTest.java
+++ b/src/test/java/org/sqlite/SQLiteDataSourceTest.java
@@ -80,4 +80,12 @@ public class SQLiteDataSourceTest {
             }
         }
     }
+
+    @Test
+    public void setBusyTimeout() {
+        final SQLiteDataSource ds = new SQLiteDataSource();
+        ds.setBusyTimeout(1234);
+        assertThat(ds.getConfig().toProperties().getProperty(SQLiteConfig.Pragma.BUSY_TIMEOUT.pragmaName)).isEqualTo("1234");
+        assertThat(ds.getConfig().getBusyTimeout()).isEqualTo(1234);
+    }
 }

--- a/src/test/java/org/sqlite/SQLiteDataSourceTest.java
+++ b/src/test/java/org/sqlite/SQLiteDataSourceTest.java
@@ -85,7 +85,11 @@ public class SQLiteDataSourceTest {
     public void setBusyTimeout() {
         final SQLiteDataSource ds = new SQLiteDataSource();
         ds.setBusyTimeout(1234);
-        assertThat(ds.getConfig().toProperties().getProperty(SQLiteConfig.Pragma.BUSY_TIMEOUT.pragmaName)).isEqualTo("1234");
+        assertThat(
+                        ds.getConfig()
+                                .toProperties()
+                                .getProperty(SQLiteConfig.Pragma.BUSY_TIMEOUT.pragmaName))
+                .isEqualTo("1234");
         assertThat(ds.getConfig().getBusyTimeout()).isEqualTo(1234);
     }
 }


### PR DESCRIPTION
add SQLiteDataSource.setBusyTimeout(int milliseconds) so that we can do:
```
    final SQLiteDataSource ds = new SQLiteDataSource();
    ds.setBusyTimeout(1234);
```

instead of doing like below, or setting up a Properties object and providing it to the SQLiteDataSource constructor:

```
    final SQLiteDataSource ds = new SQLiteDataSource();
    ds.getConfig().setBusyTimeout(2000);
```

Note that the new test will fail because it depends on the change made by https://github.com/xerial/sqlite-jdbc/pull/843.

Without that fix, the line `assertThat(ds.getConfig().getBusyTimeout()).isEqualTo(1234);` in the new test will fail.