### PR TITLE
feat: increase visibility of SQLiteConnection.setTransactionMode

### DIFF
--- a/src/main/java/org/sqlite/SQLiteConnection.java
+++ b/src/main/java/org/sqlite/SQLiteConnection.java
@@ -173,7 +173,7 @@ public abstract class SQLiteConnection implements Connection {
      * @see <a
      *     href="https://www.sqlite.org/lang_transaction.html">https://www.sqlite.org/lang_transaction.html</a>
      */
-    protected void setTransactionMode(SQLiteConfig.TransactionMode mode) {
+    public void setTransactionMode(final TransactionMode mode) {
         connectionConfig.setTransactionMode(mode);
     }
 


### PR DESCRIPTION
This is a convenience change to increase the visibility of `SQLiteConnection.setTransactionMode` so that we can use slightly simpler code like:

`((SQLiteConnection) c).setTransactionMode(SQLiteConfig.TransactionMode.IMMEDIATE);`

instead of

`((SQLiteConnection) c).getConnectionConfig().setTransactionMode(SQLiteConfig.TransactionMode.IMMEDIATE);`
