### PR TITLE
chore(SQLiteConnection): enforce currentTransactionMode not being null

### DIFF
--- a/src/main/java/org/sqlite/SQLiteConnectionConfig.java
+++ b/src/main/java/org/sqlite/SQLiteConnectionConfig.java
@@ -121,6 +121,9 @@ public class SQLiteConnectionConfig implements Cloneable {
 
     @SuppressWarnings("deprecation")
     public void setTransactionMode(SQLiteConfig.TransactionMode transactionMode) {
+        if (null == transactionMode) {
+          throw new NullPointerException("transactionMode must not be null");
+        }
         if (transactionMode == SQLiteConfig.TransactionMode.DEFFERED) {
             transactionMode = SQLiteConfig.TransactionMode.DEFERRED;
         }

--- a/src/main/java/org/sqlite/jdbc3/JDBC3Connection.java
+++ b/src/main/java/org/sqlite/jdbc3/JDBC3Connection.java
@@ -48,9 +48,7 @@ public abstract class JDBC3Connection extends SQLiteConnection {
     @SuppressWarnings("deprecation")
     public void tryEnforceTransactionMode() throws SQLException {
         // important note: read-only mode is only supported when auto-commit is disabled
-        if (getDatabase().getConfig().isExplicitReadOnly()
-                && !this.getAutoCommit()
-                && this.getCurrentTransactionMode() != null) {
+        if (getDatabase().getConfig().isExplicitReadOnly() && !this.getAutoCommit()) {
             if (isReadOnly()) {
                 // this is a read-only transaction, make sure all writing operations are rejected by
                 // the DB


### PR DESCRIPTION
having null as a possible state for `SQLiteConnection.currentTransactionMode` served no purpose.
these changes include mandating that it is not null and using that fact to simplify accordingly.