### PR TITLE
feat: remove length/ dimension of column data types in the `TYPE_NAME` field of `getColumns()`

### DIFF
--- a/src/main/java/org/sqlite/jdbc3/JDBC3DatabaseMetaData.java
+++ b/src/main/java/org/sqlite/jdbc3/JDBC3DatabaseMetaData.java
@@ -842,7 +842,6 @@ public abstract class JDBC3DatabaseMetaData extends org.sqlite.core.CoreDatabase
     protected static final Pattern TYPE_INTEGER = Pattern.compile(".*(INT|BOOL).*");
     protected static final Pattern TYPE_VARCHAR = Pattern.compile(".*(CHAR|CLOB|TEXT|BLOB).*");
     protected static final Pattern TYPE_FLOAT = Pattern.compile(".*(REAL|FLOA|DOUB|DEC|NUM).*");
-    protected static final Pattern TYPE_WITH_SIZE = Pattern.compile("^(.*)\\(\\s*\\d+\\s*(\\s*,\\s*\\d+\\s*)?\\)$");
 
 
     /**
@@ -1072,12 +1071,8 @@ public abstract class JDBC3DatabaseMetaData extends org.sqlite.core.CoreDatabase
                                     // just ignore invalid dimension formats here
                                 }
                             }
-                        }
-
-                        // remove (optional) length/ dimension of the column before returning result set
-                        Matcher regexMatcher = TYPE_WITH_SIZE.matcher(colType);
-                        if (regexMatcher.find()) {
-                            colType = regexMatcher.replaceFirst("$1").trim();
+                            // "TYPE_NAME" (colType) is without the length/ dimension
+                            colType = colType.substring(0, iStartOfDimension).trim();
                         }
 
                         int colGenerated = "2".equals(colHidden) ? 1 : 0;

--- a/src/main/java/org/sqlite/jdbc3/JDBC3DatabaseMetaData.java
+++ b/src/main/java/org/sqlite/jdbc3/JDBC3DatabaseMetaData.java
@@ -842,6 +842,8 @@ public abstract class JDBC3DatabaseMetaData extends org.sqlite.core.CoreDatabase
     protected static final Pattern TYPE_INTEGER = Pattern.compile(".*(INT|BOOL).*");
     protected static final Pattern TYPE_VARCHAR = Pattern.compile(".*(CHAR|CLOB|TEXT|BLOB).*");
     protected static final Pattern TYPE_FLOAT = Pattern.compile(".*(REAL|FLOA|DOUB|DEC|NUM).*");
+    protected static final Pattern TYPE_WITH_SIZE = Pattern.compile("^(.*)\\(\\s*\\d+\\s*(\\s*,\\s*\\d+\\s*)?\\)$");
+
 
     /**
      * @see java.sql.DatabaseMetaData#getColumns(java.lang.String, java.lang.String,
@@ -1070,6 +1072,12 @@ public abstract class JDBC3DatabaseMetaData extends org.sqlite.core.CoreDatabase
                                     // just ignore invalid dimension formats here
                                 }
                             }
+                        }
+
+                        // remove (optional) length/ dimension of the column before returning result set
+                        Matcher regexMatcher = TYPE_WITH_SIZE.matcher(colType);
+                        if (regexMatcher.find()) {
+                            colType = regexMatcher.replaceFirst("$1").trim();
                         }
 
                         int colGenerated = "2".equals(colHidden) ? 1 : 0;

--- a/src/main/java/org/sqlite/jdbc3/JDBC3DatabaseMetaData.java
+++ b/src/main/java/org/sqlite/jdbc3/JDBC3DatabaseMetaData.java
@@ -843,7 +843,6 @@ public abstract class JDBC3DatabaseMetaData extends org.sqlite.core.CoreDatabase
     protected static final Pattern TYPE_VARCHAR = Pattern.compile(".*(CHAR|CLOB|TEXT|BLOB).*");
     protected static final Pattern TYPE_FLOAT = Pattern.compile(".*(REAL|FLOA|DOUB|DEC|NUM).*");
 
-
     /**
      * @see java.sql.DatabaseMetaData#getColumns(java.lang.String, java.lang.String,
      *     java.lang.String, java.lang.String)

--- a/src/test/java/org/sqlite/DBMetaDataTest.java
+++ b/src/test/java/org/sqlite/DBMetaDataTest.java
@@ -276,6 +276,7 @@ public class DBMetaDataTest {
         assertThat(rs.getString("IS_NULLABLE")).isEqualTo("YES");
         assertThat(rs.getString("COLUMN_DEF")).isNull();
         assertThat(rs.getInt("DATA_TYPE")).isEqualTo(Types.INTEGER);
+        assertThat(rs.getString("TYPE_NAME")).isEqualTo("INTEGER");
         assertThat(rs.getInt("COLUMN_SIZE")).isEqualTo(2000000000);
         assertThat(rs.getInt("DECIMAL_DIGITS")).isEqualTo(0);
         assertThat(rs.getString("IS_AUTOINCREMENT")).isEqualTo("NO");
@@ -285,6 +286,7 @@ public class DBMetaDataTest {
         assertThat(rs.next()).isTrue();
         assertThat(rs.getString("COLUMN_NAME")).isEqualTo("fn");
         assertThat(rs.getInt("DATA_TYPE")).isEqualTo(Types.FLOAT);
+        assertThat(rs.getString("TYPE_NAME")).isEqualTo("FLOAT");
         assertThat(rs.getString("IS_NULLABLE")).isEqualTo("YES");
         assertThat(rs.getString("COLUMN_DEF")).isEqualTo("0.0");
         assertThat(rs.getInt("COLUMN_SIZE")).isEqualTo(2000000000);
@@ -296,6 +298,8 @@ public class DBMetaDataTest {
         assertThat(rs.next()).isTrue();
         assertThat(rs.getString("COLUMN_NAME")).isEqualTo("sn");
         assertThat(rs.getString("IS_NULLABLE")).isEqualTo("NO");
+        assertThat(rs.getInt("DATA_TYPE")).isEqualTo(Types.VARCHAR);
+        assertThat(rs.getString("TYPE_NAME")).isEqualTo("");
         assertThat(rs.getInt("COLUMN_SIZE")).isEqualTo(2000000000);
         assertThat(rs.getInt("DECIMAL_DIGITS")).isEqualTo(10);
         assertThat(rs.getString("COLUMN_DEF")).isNull();
@@ -305,6 +309,7 @@ public class DBMetaDataTest {
         assertThat(rs.next()).isTrue();
         assertThat(rs.getString("COLUMN_NAME")).isEqualTo("intvalue");
         assertThat(rs.getInt("DATA_TYPE")).isEqualTo(Types.INTEGER);
+        assertThat(rs.getString("TYPE_NAME")).isEqualTo("INTEGER");
         assertThat(rs.getString("IS_NULLABLE")).isEqualTo("YES");
         assertThat(rs.getInt("COLUMN_SIZE")).isEqualTo(5);
         assertThat(rs.getInt("DECIMAL_DIGITS")).isEqualTo(0);
@@ -315,6 +320,7 @@ public class DBMetaDataTest {
         assertThat(rs.next()).isTrue();
         assertThat(rs.getString("COLUMN_NAME")).isEqualTo("realvalue");
         assertThat(rs.getInt("DATA_TYPE")).isEqualTo(Types.FLOAT);
+        assertThat(rs.getString("TYPE_NAME")).isEqualTo("REAL");
         assertThat(rs.getString("IS_NULLABLE")).isEqualTo("YES");
         assertThat(rs.getInt("COLUMN_SIZE")).isEqualTo(11);
         assertThat(rs.getInt("DECIMAL_DIGITS")).isEqualTo(3);

--- a/src/test/java/org/sqlite/DBMetaDataTest.java
+++ b/src/test/java/org/sqlite/DBMetaDataTest.java
@@ -35,7 +35,7 @@ public class DBMetaDataTest {
         conn = DriverManager.getConnection("jdbc:sqlite:");
         stat = conn.createStatement();
         stat.executeUpdate(
-                "create table test (id integer primary key, fn float default 0.0, sn not null, intvalue integer(5), realvalue real(8,3));");
+                "create table test (id integer primary key, fn float default 0.0, sn not null, intvalue integer(5), realvalue real(8,3), charvalue varchar(21));");
         stat.executeUpdate("create view testView as select * from test;");
         meta = conn.getMetaData();
     }
@@ -327,6 +327,17 @@ public class DBMetaDataTest {
         assertThat(rs.getString("COLUMN_DEF")).isNull();
         assertThat(rs.next()).isFalse();
 
+        rs = meta.getColumns(null, null, "test", "charvalue");
+        assertThat(rs.next()).isTrue();
+        assertThat(rs.getString("COLUMN_NAME")).isEqualTo("charvalue");
+        assertThat(rs.getInt("DATA_TYPE")).isEqualTo(Types.VARCHAR);
+        assertThat(rs.getString("TYPE_NAME")).isEqualTo("VARCHAR");
+        assertThat(rs.getString("IS_NULLABLE")).isEqualTo("YES");
+        assertThat(rs.getInt("COLUMN_SIZE")).isEqualTo(21);
+        assertThat(rs.getInt("DECIMAL_DIGITS")).isEqualTo(0);
+        assertThat(rs.getString("COLUMN_DEF")).isNull();
+        assertThat(rs.next()).isFalse();
+
         rs = meta.getColumns(null, null, "test", "%");
         assertThat(rs.next()).isTrue();
         assertThat(rs.getString("COLUMN_NAME")).isEqualTo("id");
@@ -338,6 +349,8 @@ public class DBMetaDataTest {
         assertThat(rs.getString("COLUMN_NAME")).isEqualTo("intvalue");
         assertThat(rs.next()).isTrue();
         assertThat(rs.getString("COLUMN_NAME")).isEqualTo("realvalue");
+        assertThat(rs.next()).isTrue();
+        assertThat(rs.getString("COLUMN_NAME")).isEqualTo("charvalue");
         assertThat(rs.next()).isFalse();
 
         rs = meta.getColumns(null, null, "test", "%n");
@@ -364,6 +377,9 @@ public class DBMetaDataTest {
         assertThat(rs.next()).isTrue();
         assertThat(rs.getString("TABLE_NAME")).isEqualTo("test");
         assertThat(rs.getString("COLUMN_NAME")).isEqualTo("realvalue");
+        assertThat(rs.next()).isTrue();
+        assertThat(rs.getString("TABLE_NAME")).isEqualTo("test");
+        assertThat(rs.getString("COLUMN_NAME")).isEqualTo("charvalue");
         // VIEW "testView"
         assertThat(rs.next()).isTrue();
         assertThat(rs.getString("TABLE_NAME")).isEqualTo("testView");
@@ -380,6 +396,9 @@ public class DBMetaDataTest {
         assertThat(rs.next()).isTrue();
         assertThat(rs.getString("TABLE_NAME")).isEqualTo("testView");
         assertThat(rs.getString("COLUMN_NAME")).isEqualTo("realvalue");
+        assertThat(rs.next()).isTrue();
+        assertThat(rs.getString("TABLE_NAME")).isEqualTo("testView");
+        assertThat(rs.getString("COLUMN_NAME")).isEqualTo("charvalue");
         assertThat(rs.next()).isFalse();
 
         rs = meta.getColumns(null, null, "%", "%");
@@ -407,6 +426,8 @@ public class DBMetaDataTest {
         assertThat(rs.getString("COLUMN_NAME")).isEqualTo("intvalue");
         assertThat(rs.next()).isTrue();
         assertThat(rs.getString("COLUMN_NAME")).isEqualTo("realvalue");
+        assertThat(rs.next()).isTrue();
+        assertThat(rs.getString("COLUMN_NAME")).isEqualTo("charvalue");
         // VIEW "testView"
         assertThat(rs.next()).isTrue();
         assertThat(rs.getString("TABLE_NAME")).isEqualTo("testView");
@@ -419,6 +440,8 @@ public class DBMetaDataTest {
         assertThat(rs.getString("COLUMN_NAME")).isEqualTo("intvalue");
         assertThat(rs.next()).isTrue();
         assertThat(rs.getString("COLUMN_NAME")).isEqualTo("realvalue");
+        assertThat(rs.next()).isTrue();
+        assertThat(rs.getString("COLUMN_NAME")).isEqualTo("charvalue");
         assertThat(rs.next()).isFalse();
 
         rs = meta.getColumns(null, null, "doesnotexist", "%");


### PR DESCRIPTION
If columns are defined with `intvalue integer(5)`, `realvalue real(8,3)`, or `charvalue varchar(21)` for example, return `INTEGER`, `REAL` or `VARCHAR` respectively. This is consistent with how other JDBC drivers return the `TYPE_NAME` field in [`DatabaseMetaData.getColumns()`](https://docs.oracle.com/javase/8/docs/api/java/sql/DatabaseMetaData.html#getColumns-java.lang.String-java.lang.String-java.lang.String-java.lang.String-).

Tests are in https://github.com/xerial/sqlite-jdbc/blob/master/src/test/java/org/sqlite/DBMetaDataTest.java#L271