### PR TITLE
fix(jdbc): PreparedStatement getParameterType and getParameterTypeName

### DIFF
--- a/src/main/java/org/sqlite/core/CoreStatement.java
+++ b/src/main/java/org/sqlite/core/CoreStatement.java
@@ -140,4 +140,10 @@ public abstract class CoreStatement implements Codes {
     }
 
     public abstract ResultSet executeQuery(String sql, boolean closeStmt) throws SQLException;
+
+    protected void checkIndex(int index) throws SQLException {
+        if (index < 1 || index > batch.length) {
+            throw new SQLException("Parameter index is invalid");
+        }
+    }
 }

--- a/src/main/java/org/sqlite/jdbc3/JDBC3PreparedStatement.java
+++ b/src/main/java/org/sqlite/jdbc3/JDBC3PreparedStatement.java
@@ -10,6 +10,7 @@ import java.sql.Array;
 import java.sql.Blob;
 import java.sql.Clob;
 import java.sql.Date;
+import java.sql.JDBCType;
 import java.sql.ParameterMetaData;
 import java.sql.Ref;
 import java.sql.ResultSet;
@@ -154,13 +155,29 @@ public abstract class JDBC3PreparedStatement extends CorePreparedStatement {
     }
 
     /** @see java.sql.ParameterMetaData#getParameterTypeName(int) */
-    public String getParameterTypeName(int pos) {
-        return "VARCHAR";
+    public String getParameterTypeName(int pos) throws SQLException {
+        checkIndex(pos);
+        return JDBCType.valueOf(getParameterType(pos)).getName();
     }
 
     /** @see java.sql.ParameterMetaData#getParameterType(int) */
-    public int getParameterType(int pos) {
-        return Types.VARCHAR;
+    public int getParameterType(int pos) throws SQLException {
+        checkIndex(pos);
+        Object paramValue = batch[pos - 1];
+
+        if (paramValue == null) {
+            return Types.NULL;
+        } else if (paramValue instanceof Integer
+                || paramValue instanceof Short
+                || paramValue instanceof Boolean) {
+            return Types.INTEGER;
+        } else if (paramValue instanceof Long) {
+            return Types.BIGINT;
+        } else if (paramValue instanceof Double || paramValue instanceof Float) {
+            return Types.REAL;
+        } else {
+            return Types.VARCHAR;
+        }
     }
 
     /** @see java.sql.ParameterMetaData#getParameterMode(int) */

--- a/src/test/java/org/sqlite/PrepStmtTest.java
+++ b/src/test/java/org/sqlite/PrepStmtTest.java
@@ -777,4 +777,26 @@ public class PrepStmtTest {
             assertThat(meta.getColumnClassName(1)).isEqualTo("java.lang.Object");
         }
     }
+
+    @Test
+    public void getParameterTypeTest() throws SQLException {
+        stat.executeUpdate("create table t_int(i INT)");
+
+        try (PreparedStatement ps = conn.prepareStatement("INSERT INTO t_int VALUES(?)")) {
+            ps.setLong(1, 100);
+            assertThat(ps.getParameterMetaData().getParameterType(1)).isEqualTo(Types.BIGINT);
+            assertThat(ps.getParameterMetaData().getParameterTypeName(1)).isEqualTo("BIGINT");
+        }
+
+        stat.executeUpdate("create table t_real(a REAL, b REAL)");
+
+        try (PreparedStatement ps = conn.prepareStatement("INSERT INTO t_real VALUES(?, ?)")) {
+            ps.setDouble(1, 100.0);
+            ps.setFloat(2, 100.0f);
+            assertThat(ps.getParameterMetaData().getParameterType(1)).isEqualTo(Types.REAL);
+            assertThat(ps.getParameterMetaData().getParameterTypeName(1)).isEqualTo("REAL");
+            assertThat(ps.getParameterMetaData().getParameterType(2)).isEqualTo(Types.REAL);
+            assertThat(ps.getParameterMetaData().getParameterTypeName(2)).isEqualTo("REAL");
+        }
+    }
 }


### PR DESCRIPTION
Implements JDBC3PreparedStatement getParameterType and getParameterTypeName.
It returns the JDBC type based on the parameter class.