### PR TITLE
feat: Add support of LocalDate, LocalTime, LocalDateTime in JDBC4ResultSet.

### DIFF
--- a/src/main/java/org/sqlite/jdbc4/JDBC4ResultSet.java
+++ b/src/main/java/org/sqlite/jdbc4/JDBC4ResultSet.java
@@ -1,5 +1,8 @@
 package org.sqlite.jdbc4;
 
+import org.sqlite.core.CoreStatement;
+import org.sqlite.jdbc3.JDBC3ResultSet;
+
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -23,9 +26,10 @@ import java.sql.SQLFeatureNotSupportedException;
 import java.sql.SQLXML;
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.Map;
-import org.sqlite.core.CoreStatement;
-import org.sqlite.jdbc3.JDBC3ResultSet;
 
 public class JDBC4ResultSet extends JDBC3ResultSet implements ResultSet, ResultSetMetaData {
 
@@ -310,8 +314,10 @@ public class JDBC4ResultSet extends JDBC3ResultSet implements ResultSet, ResultS
         throw new SQLFeatureNotSupportedException();
     }
 
+    @SuppressWarnings("deprecation")
     public <T> T getObject(int columnIndex, Class<T> type) throws SQLException {
         if (type == null) throw new SQLException("requested type cannot be null");
+
         if (type == String.class) return type.cast(getString(columnIndex));
         if (type == Boolean.class) return type.cast(getBoolean(columnIndex));
         if (type == BigDecimal.class) return type.cast(getBigDecimal(columnIndex));
@@ -319,6 +325,41 @@ public class JDBC4ResultSet extends JDBC3ResultSet implements ResultSet, ResultS
         if (type == Date.class) return type.cast(getDate(columnIndex));
         if (type == Time.class) return type.cast(getTime(columnIndex));
         if (type == Timestamp.class) return type.cast(getTimestamp(columnIndex));
+
+        if (type == LocalDate.class) {
+            Date date = getDate(columnIndex);
+
+            int year = date.getYear() + 1900;
+            int month = date.getMonth() + 1;
+            int day = date.getDate();
+
+            return type.cast(LocalDate.of(year, month, day));
+        }
+
+        if (type == LocalTime.class) {
+            Time time = getTime(columnIndex);
+
+            int hour = time.getHours();
+            int minute = time.getMinutes();
+            int second = time.getSeconds();
+
+            return type.cast(LocalTime.of(hour, minute, second));
+        }
+
+        if (type == LocalDateTime.class) {
+            Date date = getDate(columnIndex);
+            Time time = getTime(columnIndex);
+
+            int year = date.getYear() + 1900;
+            int month = date.getMonth() + 1;
+            int day = date.getDate();
+
+            int hour = time.getHours();
+            int minute = time.getMinutes();
+            int second = time.getSeconds();
+
+            return type.cast(LocalDateTime.of(year, month, day, hour, minute, second));
+        }
 
         int columnType = safeGetColumnType(markCol(columnIndex));
         if (type == Double.class) {

--- a/src/main/java/org/sqlite/jdbc4/JDBC4ResultSet.java
+++ b/src/main/java/org/sqlite/jdbc4/JDBC4ResultSet.java
@@ -327,23 +327,37 @@ public class JDBC4ResultSet extends JDBC3ResultSet implements ResultSet, ResultS
         if (type == Timestamp.class) return type.cast(getTimestamp(columnIndex));
 
         if (type == LocalDate.class) {
-            Date date = getDate(columnIndex);
+            try {
+                Date date = getDate(columnIndex);
 
-            int year = date.getYear() + 1900;
-            int month = date.getMonth() + 1;
-            int day = date.getDate();
+                int year = date.getYear() + 1900;
+                int month = date.getMonth() + 1;
+                int day = date.getDate();
 
-            return type.cast(LocalDate.of(year, month, day));
+                return type.cast(LocalDate.of(year, month, day));
+            } catch (SQLException sqlException) {
+                // If the FastDateParser failed, try parse it with LocalDate.
+                // It's a workaround for a value like '2022-12-1' (i.e no time presents).
+
+                return type.cast(LocalDate.parse(getString(columnIndex)));
+            }
         }
 
         if (type == LocalTime.class) {
-            Time time = getTime(columnIndex);
+            try {
+                Time time = getTime(columnIndex);
 
-            int hour = time.getHours();
-            int minute = time.getMinutes();
-            int second = time.getSeconds();
+                int hour = time.getHours();
+                int minute = time.getMinutes();
+                int second = time.getSeconds();
 
-            return type.cast(LocalTime.of(hour, minute, second));
+                return type.cast(LocalTime.of(hour, minute, second));
+            } catch (SQLException sqlException) {
+                // If the FastDateParser failed, try parse it with LocalTime.
+                // It's a workaround for a value like '11:22:22' (i.e no date presents).
+
+                return type.cast(LocalTime.parse(getString(columnIndex)));
+            }
         }
 
         if (type == LocalDateTime.class) {

--- a/src/main/java/org/sqlite/jdbc4/JDBC4ResultSet.java
+++ b/src/main/java/org/sqlite/jdbc4/JDBC4ResultSet.java
@@ -1,8 +1,5 @@
 package org.sqlite.jdbc4;
 
-import org.sqlite.core.CoreStatement;
-import org.sqlite.jdbc3.JDBC3ResultSet;
-
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -30,6 +27,8 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.Map;
+import org.sqlite.core.CoreStatement;
+import org.sqlite.jdbc3.JDBC3ResultSet;
 
 public class JDBC4ResultSet extends JDBC3ResultSet implements ResultSet, ResultSetMetaData {
 

--- a/src/test/java/org/sqlite/ResultSetTest.java
+++ b/src/test/java/org/sqlite/ResultSetTest.java
@@ -19,6 +19,7 @@ import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.Objects;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -335,22 +336,21 @@ class ResultSetTest {
     void testJdk8AddedDateTimeObjects() throws SQLException {
         stat.executeUpdate("create table datetime_test(c1)");
         stat.executeUpdate("insert into datetime_test values ('2021-11-09 11:20:58')");
+        stat.executeUpdate("insert into datetime_test values ('2021-11-09')");
+        stat.executeUpdate("insert into datetime_test values ('11:20:58')");
 
         ResultSet rs = stat.executeQuery("select * from datetime_test");
 
         rs.next();
+        assertThat(rs.getObject(1, LocalDate.class)).isEqualTo(LocalDate.of(2021, 11, 9));
+        assertThat(rs.getObject(1, LocalTime.class)).isEqualTo(LocalTime.of(11, 20, 58));
+        assertThat(rs.getObject(1, LocalDateTime.class)).isEqualTo(LocalDateTime.of(2021, 11, 9, 11, 20, 58));
 
-        Assertions.assertEquals(
-                LocalDate.of(2021, 11, 9),
-                rs.getObject(1, LocalDate.class));
+        rs.next();
+        assertThat(rs.getObject(1, LocalDate.class)).isEqualTo(LocalDate.of(2021, 11, 9));
 
-        Assertions.assertEquals(
-                LocalTime.of(11, 20, 58),
-                rs.getObject(1, LocalTime.class));
-
-        Assertions.assertEquals(
-                LocalDateTime.of(2021, 11, 9, 11, 20, 58),
-                rs.getObject(1, LocalDateTime.class));
+        rs.next();
+        assertThat(rs.getObject(1, LocalTime.class)).isEqualTo(LocalTime.of(11, 20, 58));
     }
 
     @Test

--- a/src/test/java/org/sqlite/ResultSetTest.java
+++ b/src/test/java/org/sqlite/ResultSetTest.java
@@ -1,9 +1,7 @@
 package org.sqlite;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import java.math.BigDecimal;
 import java.sql.Connection;
@@ -19,10 +17,9 @@ import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.util.Objects;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 class ResultSetTest {
 
@@ -344,7 +341,8 @@ class ResultSetTest {
         rs.next();
         assertThat(rs.getObject(1, LocalDate.class)).isEqualTo(LocalDate.of(2021, 11, 9));
         assertThat(rs.getObject(1, LocalTime.class)).isEqualTo(LocalTime.of(11, 20, 58));
-        assertThat(rs.getObject(1, LocalDateTime.class)).isEqualTo(LocalDateTime.of(2021, 11, 9, 11, 20, 58));
+        assertThat(rs.getObject(1, LocalDateTime.class))
+                .isEqualTo(LocalDateTime.of(2021, 11, 9, 11, 20, 58));
 
         rs.next();
         assertThat(rs.getObject(1, LocalDate.class)).isEqualTo(LocalDate.of(2021, 11, 9));

--- a/src/test/java/org/sqlite/ResultSetTest.java
+++ b/src/test/java/org/sqlite/ResultSetTest.java
@@ -1,7 +1,9 @@
 package org.sqlite;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.sql.Connection;
@@ -14,11 +16,14 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Time;
 import java.sql.Timestamp;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 
-public class ResultSetTest {
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+class ResultSetTest {
 
     private Connection conn;
     private Statement stat;
@@ -39,70 +44,70 @@ public class ResultSetTest {
     }
 
     @Test
-    public void testTableColumnLowerNowFindLowerCaseColumn() throws SQLException {
+    void testTableColumnLowerNowFindLowerCaseColumn() throws SQLException {
         ResultSet resultSet = stat.executeQuery("select * from test");
         assertThat(resultSet.next()).isTrue();
         assertThat(resultSet.findColumn("id")).isEqualTo(1);
     }
 
     @Test
-    public void testTableColumnLowerNowFindUpperCaseColumn() throws SQLException {
+    void testTableColumnLowerNowFindUpperCaseColumn() throws SQLException {
         ResultSet resultSet = stat.executeQuery("select * from test");
         assertThat(resultSet.next()).isTrue();
         assertThat(resultSet.findColumn("ID")).isEqualTo(1);
     }
 
     @Test
-    public void testTableColumnLowerNowFindMixedCaseColumn() throws SQLException {
+    void testTableColumnLowerNowFindMixedCaseColumn() throws SQLException {
         ResultSet resultSet = stat.executeQuery("select * from test");
         assertThat(resultSet.next()).isTrue();
         assertThat(resultSet.findColumn("Id")).isEqualTo(1);
     }
 
     @Test
-    public void testTableColumnUpperNowFindLowerCaseColumn() throws SQLException {
+    void testTableColumnUpperNowFindLowerCaseColumn() throws SQLException {
         ResultSet resultSet = stat.executeQuery("select * from test");
         assertThat(resultSet.next()).isTrue();
         assertThat(resultSet.findColumn("description")).isEqualTo(2);
     }
 
     @Test
-    public void testTableColumnUpperNowFindUpperCaseColumn() throws SQLException {
+    void testTableColumnUpperNowFindUpperCaseColumn() throws SQLException {
         ResultSet resultSet = stat.executeQuery("select * from test");
         assertThat(resultSet.next()).isTrue();
         assertThat(resultSet.findColumn("DESCRIPTION")).isEqualTo(2);
     }
 
     @Test
-    public void testTableColumnUpperNowFindMixedCaseColumn() throws SQLException {
+    void testTableColumnUpperNowFindMixedCaseColumn() throws SQLException {
         ResultSet resultSet = stat.executeQuery("select * from test");
         assertThat(resultSet.next()).isTrue();
         assertThat(resultSet.findColumn("Description")).isEqualTo(2);
     }
 
     @Test
-    public void testTableColumnMixedNowFindLowerCaseColumn() throws SQLException {
+    void testTableColumnMixedNowFindLowerCaseColumn() throws SQLException {
         ResultSet resultSet = stat.executeQuery("select * from test");
         assertThat(resultSet.next()).isTrue();
         assertThat(resultSet.findColumn("foo")).isEqualTo(3);
     }
 
     @Test
-    public void testTableColumnMixedNowFindUpperCaseColumn() throws SQLException {
+    void testTableColumnMixedNowFindUpperCaseColumn() throws SQLException {
         ResultSet resultSet = stat.executeQuery("select * from test");
         assertThat(resultSet.next()).isTrue();
         assertThat(resultSet.findColumn("FOO")).isEqualTo(3);
     }
 
     @Test
-    public void testTableColumnMixedNowFindMixedCaseColumn() throws SQLException {
+    void testTableColumnMixedNowFindMixedCaseColumn() throws SQLException {
         ResultSet resultSet = stat.executeQuery("select * from test");
         assertThat(resultSet.next()).isTrue();
         assertThat(resultSet.findColumn("fOo")).isEqualTo(3);
     }
 
     @Test
-    public void testSelectWithTableNameAliasNowFindWithoutTableNameAlias() throws SQLException {
+    void testSelectWithTableNameAliasNowFindWithoutTableNameAlias() throws SQLException {
         ResultSet resultSet = stat.executeQuery("select t.id from test as t");
         assertThat(resultSet.next()).isTrue();
         assertThat(resultSet.findColumn("id")).isEqualTo(1);
@@ -114,7 +119,7 @@ public class ResultSetTest {
      * the column is unspecified"
      */
     @Test
-    public void testSelectWithTableNameAliasNowNotFindWithTableNameAlias() throws SQLException {
+    void testSelectWithTableNameAliasNowNotFindWithTableNameAlias() throws SQLException {
         ResultSet resultSet = stat.executeQuery("select t.id from test as t");
         assertThat(resultSet.next()).isTrue();
         assertThatExceptionOfType(SQLException.class)
@@ -122,14 +127,14 @@ public class ResultSetTest {
     }
 
     @Test
-    public void testSelectWithTableNameNowFindWithoutTableName() throws SQLException {
+    void testSelectWithTableNameNowFindWithoutTableName() throws SQLException {
         ResultSet resultSet = stat.executeQuery("select test.id from test");
         assertThat(resultSet.next()).isTrue();
         assertThat(resultSet.findColumn("id")).isEqualTo(1);
     }
 
     @Test
-    public void testSelectWithTableNameNowNotFindWithTableName() throws SQLException {
+    void testSelectWithTableNameNowNotFindWithTableName() throws SQLException {
         ResultSet resultSet = stat.executeQuery("select test.id from test");
         assertThat(resultSet.next()).isTrue();
         assertThatExceptionOfType(SQLException.class)
@@ -137,7 +142,7 @@ public class ResultSetTest {
     }
 
     @Test
-    public void testCloseStatement() throws SQLException {
+    void testCloseStatement() throws SQLException {
         ResultSet resultSet = stat.executeQuery("select test.id from test");
 
         stat.close();
@@ -151,7 +156,7 @@ public class ResultSetTest {
     }
 
     @Test
-    public void testReturnsNonAsciiCodepoints() throws SQLException {
+    void testReturnsNonAsciiCodepoints() throws SQLException {
         String nonAsciiString = "국정의 중요한 사항에 관한";
         PreparedStatement pstat = conn.prepareStatement("select ?");
         pstat.setString(1, nonAsciiString);
@@ -164,14 +169,14 @@ public class ResultSetTest {
     }
 
     @Test
-    public void testFindColumnOnEmptyResultSet() throws SQLException {
+    void testFindColumnOnEmptyResultSet() throws SQLException {
         ResultSet resultSet = stat.executeQuery("select * from test where id = 0");
         assertThat(resultSet.next()).isFalse();
         assertThat(resultSet.findColumn("id")).isEqualTo(1);
     }
 
     @Test
-    public void testNumericTypes() throws SQLException {
+    void testNumericTypes() throws SQLException {
         stat.executeUpdate("create table numeric(c1, c2, c3)");
         stat.executeUpdate("insert into numeric values (1, 1.1, null)");
 
@@ -196,7 +201,7 @@ public class ResultSetTest {
     }
 
     @Test
-    public void testGetBigDecimal() throws SQLException {
+    void testGetBigDecimal() throws SQLException {
         stat.executeUpdate(
                 "create table bigdecimal(c1, c2 integer, c3 real, c4 double, c5 decimal, c6 numeric, c7 float)");
         stat.executeUpdate("insert into bigdecimal values (1, 2, 3, 4, 5, 6, 7)");
@@ -324,6 +329,28 @@ public class ResultSetTest {
                 .withMessageContaining("Bad value for type Integer");
 
         assertThat(rs.next()).isFalse();
+    }
+
+    @Test
+    void testJdk8AddedDateTimeObjects() throws SQLException {
+        stat.executeUpdate("create table datetime_test(c1)");
+        stat.executeUpdate("insert into datetime_test values ('2021-11-09 11:20:58')");
+
+        ResultSet rs = stat.executeQuery("select * from datetime_test");
+
+        rs.next();
+
+        Assertions.assertEquals(
+                LocalDate.of(2021, 11, 9),
+                rs.getObject(1, LocalDate.class));
+
+        Assertions.assertEquals(
+                LocalTime.of(11, 20, 58),
+                rs.getObject(1, LocalTime.class));
+
+        Assertions.assertEquals(
+                LocalDateTime.of(2021, 11, 9, 11, 20, 58),
+                rs.getObject(1, LocalDateTime.class));
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change
Support LocalDate, LocalTime, LocalDateTime in ResultSet. They are new time-representing classes that appears in JDK 8.

## Why this PR proposed
I'm using SQLite as a embedded database for testing in my project. There's a POJO that uses LocalDate. When I'm trying to use MyBatis (an ORM framework) to execute query that returns the POJO above, it saids the LocalDate is unsupported. 

## Brief changelog
Add more type handling statement in getObject method.