### PR TITLE
ci: update to GraalVM 23

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,19 +69,14 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        java: [ 11, 17 ]
+        java: [ 17, 20 ]
         profiles: ['native', 'native,native-exported']
-        exclude: # Exclusions can be removed from GraalVM 23.0: https://github.com/oracle/graal/pull/5932
-          - os: ubuntu-latest
-            profiles: 'native,native-exported'
-          - os: macos-latest
-            profiles: 'native,native-exported'
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
       - uses: graalvm/setup-graalvm@v1
         with:
-          version: '22.3.0'
+          version: '23.0.0'
           java-version: ${{ matrix.java }}
           components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        java: [ '17.0.7', '20.0.1' ]
+        java: [ '17', '20' ]
         profiles: ['native', 'native,native-exported']
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,16 +69,15 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        java: [ 17, 20 ]
+        java: [ '17.0.7', '20.0.1' ]
         profiles: ['native', 'native,native-exported']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
       - uses: graalvm/setup-graalvm@v1
         with:
-          version: '23.0.0'
           java-version: ${{ matrix.java }}
-          components: 'native-image'
+          distribution: 'graalvm-community'
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Test
         run: mvn --batch-mode --no-transfer-progress -P ${{ matrix.profiles }} integration-test

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>5.9.3</junit.version>
         <surefire.version>3.1.2</surefire.version>
-        <graalvm.version>22.3.2</graalvm.version>
+        <graalvm.version>23.0.0</graalvm.version>
         <java9.sourceDirectory>${project.basedir}/src/main/java9</java9.sourceDirectory>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>5.9.3</junit.version>
         <surefire.version>3.1.2</surefire.version>
-        <graalvm.version>23.0.0</graalvm.version>
+        <graalvm.version>22.3.2</graalvm.version>
         <java9.sourceDirectory>${project.basedir}/src/main/java9</java9.sourceDirectory>
     </properties>
 

--- a/src/main/java/org/sqlite/SQLiteJDBCLoader.java
+++ b/src/main/java/org/sqlite/SQLiteJDBCLoader.java
@@ -298,6 +298,17 @@ public class SQLiteJDBCLoader {
         }
     }
 
+    private static boolean loadNativeLibraryJdk() {
+        try {
+            System.loadLibrary(LibraryLoaderUtil.NATIVE_LIB_BASE_NAME);
+            return true;
+        } catch (UnsatisfiedLinkError e) {
+            System.err.println("Failed to load native library through System.loadLibrary");
+            e.printStackTrace();
+            return false;
+        }
+    }
+
     /**
      * Loads SQLite native library using given path and name of the library.
      *
@@ -356,6 +367,12 @@ public class SQLiteJDBCLoader {
             } else {
                 triedPaths.add(ldPath);
             }
+        }
+
+        // As an ultimate last resort, try loading through System.loadLibrary
+        if (loadNativeLibraryJdk()) {
+            extracted = true;
+            return;
         }
 
         extracted = false;

--- a/src/main/java/org/sqlite/util/LibraryLoaderUtil.java
+++ b/src/main/java/org/sqlite/util/LibraryLoaderUtil.java
@@ -3,6 +3,9 @@ package org.sqlite.util;
 import org.sqlite.SQLiteJDBCLoader;
 
 public class LibraryLoaderUtil {
+
+    public static final String NATIVE_LIB_BASE_NAME = "sqlitejdbc";
+
     /**
      * Get the OS-specific resource directory within the jar, where the relevant sqlitejdbc native
      * library is located.
@@ -15,7 +18,7 @@ public class LibraryLoaderUtil {
 
     /** Get the OS-specific name of the sqlitejdbc native library. */
     public static String getNativeLibName() {
-        return System.mapLibraryName("sqlitejdbc");
+        return System.mapLibraryName(NATIVE_LIB_BASE_NAME);
     }
 
     public static boolean hasNativeLib(String path, String libraryName) {


### PR DESCRIPTION
GraalVM 23.0.0 has been released.
This updates the CI to this version. This release should include https://github.com/oracle/graal/pull/5932 which enables the `native-exported` flow on unix and darwin systems.

The  `org.graalvm.sdk:graal-sdk` dependency in the pom is still set to `22.3.2`, the latest release is compiled with java 17 so that would force anyone using native-image to use at least a java 17 jdk.
Going forward, GraalVM releases will follow the latest LTR releases from java, so the next version (23.1.0) will likely require java 21.

This is still a draft as the CI will keep failing because the `graalvm/setup-graalvm` action does not support the latest release yet: https://github.com/graalvm/setup-graalvm/issues/45