### PR TITLE
fix: correct the exception message when backup fails

### DIFF
--- a/src/main/java/org/sqlite/ExtendedCommand.java
+++ b/src/main/java/org/sqlite/ExtendedCommand.java
@@ -103,7 +103,7 @@ public class ExtendedCommand {
             int rc = db.backup(srcDB, destFile, null);
 
             if (rc != SQLiteErrorCode.SQLITE_OK.code) {
-                throw DB.newSQLException(rc, "Restore failed");
+                throw DB.newSQLException(rc, "Backup failed");
             }
         }
     }


### PR DESCRIPTION
Fixed the exception message when backup fails from "Restore failed" to "Backup failed"