### PR TITLE
ci: update native-image testing to GraalVM 21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        java: [ '17', '20' ]
+        java: [ '17', '21' ]
         profiles: ['native', 'native,native-exported']
     runs-on: ${{ matrix.os }}
     steps:

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>5.10.0</junit.version>
         <surefire.version>3.1.2</surefire.version>
-        <graalvm.version>22.3.2</graalvm.version>
+        <graalvm.version>23.1.0</graalvm.version>
         <java9.sourceDirectory>${project.basedir}/src/main/java9</java9.sourceDirectory>
     </properties>
 
@@ -344,7 +344,7 @@
                     <plugin>
                         <groupId>org.graalvm.buildtools</groupId>
                         <artifactId>native-maven-plugin</artifactId>
-                        <version>0.9.25</version>
+                        <version>0.9.27</version>
                         <extensions>true</extensions>
                         <executions>
                             <execution>
@@ -414,7 +414,7 @@
         -->
         <dependency>
             <groupId>org.graalvm.sdk</groupId>
-            <artifactId>graal-sdk</artifactId>
+            <artifactId>nativeimage</artifactId>
             <version>${graalvm.version}</version>
             <scope>provided</scope>
         </dependency>
@@ -429,6 +429,16 @@
             <artifactId>assertj-core</artifactId>
             <version>3.24.2</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <!--
+                    assertj bundles an outdated version of byte-buddy.
+                    This exclusion this makes sure the one junit brings in is used.
+                    -->
+                    <groupId>net.bytebuddy</groupId>
+                    <artifactId>byte-buddy</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.junit-pioneer</groupId>

--- a/src/main/java9/module-info.java
+++ b/src/main/java9/module-info.java
@@ -2,7 +2,7 @@ module org.xerial.sqlitejdbc {
 
     requires transitive java.sql;
     requires transitive java.sql.rowset;
-    requires static org.graalvm.sdk;
+    requires static org.graalvm.nativeimage;
 
     exports org.sqlite;
     exports org.sqlite.core;


### PR DESCRIPTION
Update the native-image GitHub Actions flow to test against GraalVM 21 instead of GraalVM 20.
The change of the `org.graalvm.sdk:graal-sdk` to `org.graalvm.sdk:nativeimage` is a rename described here: https://www.graalvm.org/release-notes/JDK_21#refactoring-graalvm-sdk