### PR TITLE
fix(native-image): do not initialize logging framework at build-time

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -365,7 +365,6 @@
                                 -->
                                 <buildArg>
                                     -H:ServiceLoaderFeatureExcludeServiceProviders=com.tngtech.archunit.junit.internal.ArchUnitTestEngine
-                                    --initialize-at-build-time=ch.qos.logback
                                 </buildArg>
                             </buildArgs>
                         </configuration>
@@ -396,9 +395,7 @@
                         <artifactId>native-maven-plugin</artifactId>
                         <configuration>
                             <buildArgs combine.children="append">
-                                <buildArg>
-                                    -Dorg.sqlite.lib.exportPath=${project.build.directory}
-                                </buildArg>
+                                <buildArg>-Dorg.sqlite.lib.exportPath=${project.build.directory}</buildArg>
                             </buildArgs>
                         </configuration>
                     </plugin>

--- a/src/main/java/org/sqlite/SQLiteJDBCLoader.java
+++ b/src/main/java/org/sqlite/SQLiteJDBCLoader.java
@@ -398,7 +398,6 @@ public class SQLiteJDBCLoader {
      * executable, and we're eliminating the IO operations as well.
      */
     public static final class VersionHolder {
-        private static final Logger logger = LoggerFactory.getLogger(VersionHolder.class);
         private static final String VERSION;
 
         static {
@@ -420,7 +419,10 @@ public class SQLiteJDBCLoader {
                     version = version.trim().replaceAll("[^0-9\\.]", "");
                 }
             } catch (IOException e) {
-                logger.atError()
+                // inline creation of logger to avoid build-time initialization of the logging
+                // framework in native-image
+                LoggerFactory.getLogger(VersionHolder.class)
+                        .atError()
                         .setCause(e)
                         .log("Could not read version from file: {}", versionFile);
             }

--- a/src/main/java/org/sqlite/jdbc3/JDBC3DatabaseMetaData.java
+++ b/src/main/java/org/sqlite/jdbc3/JDBC3DatabaseMetaData.java
@@ -31,7 +31,6 @@ import org.sqlite.util.QueryUtils;
 import org.sqlite.util.StringUtils;
 
 public abstract class JDBC3DatabaseMetaData extends CoreDatabaseMetaData {
-    private static final Logger logger = LoggerFactory.getLogger(JDBC3DatabaseMetaData.class);
 
     private static String driverName;
     private static String driverVersion;
@@ -965,14 +964,14 @@ public abstract class JDBC3DatabaseMetaData extends CoreDatabaseMetaData {
                         try {
                             rsColAutoinc.close();
                         } catch (Exception e) {
-                            logger.atError().setCause(e).log();
+                            LogHolder.logger.atError().setCause(e).log();
                         }
                     }
                     if (statColAutoinc != null) {
                         try {
                             statColAutoinc.close();
                         } catch (Exception e) {
-                            logger.atError().setCause(e).log();
+                            LogHolder.logger.atError().setCause(e).log();
                         }
                     }
                 }
@@ -1123,7 +1122,7 @@ public abstract class JDBC3DatabaseMetaData extends CoreDatabaseMetaData {
                 try {
                     rs.close();
                 } catch (Exception e) {
-                    logger.atError().setCause(e).log();
+                    LogHolder.logger.atError().setCause(e).log();
                 }
             }
         }
@@ -2239,5 +2238,13 @@ public abstract class JDBC3DatabaseMetaData extends CoreDatabaseMetaData {
             name = name.substring(1, name.length() - 1);
         }
         return name;
+    }
+
+    /**
+     * Class-wrapper around the logger object to avoid build-time initialization of the logging
+     * framework in native-image
+     */
+    private static class LogHolder {
+        private static final Logger logger = LoggerFactory.getLogger(JDBC3DatabaseMetaData.class);
     }
 }

--- a/src/main/java/org/sqlite/util/OSInfo.java
+++ b/src/main/java/org/sqlite/util/OSInfo.java
@@ -40,7 +40,6 @@ import org.slf4j.LoggerFactory;
  * @author leo
  */
 public class OSInfo {
-    private static final Logger logger = LoggerFactory.getLogger(OSInfo.class);
     protected static ProcessRunner processRunner = new ProcessRunner();
     private static final HashMap<String, String> archMapping = new HashMap<>();
 
@@ -161,7 +160,7 @@ public class OSInfo {
         try {
             return processRunner.runAndWaitFor("uname -m");
         } catch (Throwable e) {
-            logger.atError().setCause(e).log("Error while running uname -m");
+            LogHolder.logger.atError().setCause(e).log("Error while running uname -m");
             return "unknown";
         }
     }
@@ -222,7 +221,8 @@ public class OSInfo {
                         return "armv7";
                     }
                 } else {
-                    logger.atWarn()
+                    LogHolder.logger
+                            .atWarn()
                             .log(
                                     "readelf not found. Cannot check if running on an armhf system, armel architecture will be presumed");
                 }
@@ -271,5 +271,13 @@ public class OSInfo {
 
     static String translateArchNameToFolderName(String archName) {
         return archName.replaceAll("\\W", "");
+    }
+
+    /**
+     * Class-wrapper around the logger object to avoid build-time initialization of the logging
+     * framework in native-image
+     */
+    private static class LogHolder {
+        private static final Logger logger = LoggerFactory.getLogger(OSInfo.class);
     }
 }

--- a/src/main/java9/org/sqlite/nativeimage/SqliteJdbcFeature.java
+++ b/src/main/java9/org/sqlite/nativeimage/SqliteJdbcFeature.java
@@ -4,7 +4,6 @@ import org.graalvm.nativeimage.hosted.Feature;
 import org.graalvm.nativeimage.hosted.RuntimeClassInitialization;
 import org.graalvm.nativeimage.hosted.RuntimeJNIAccess;
 import org.graalvm.nativeimage.hosted.RuntimeResourceAccess;
-import org.slf4j.LoggerFactory;
 import org.sqlite.*;
 import org.sqlite.core.DB;
 import org.sqlite.core.NativeDB;
@@ -29,7 +28,6 @@ public class SqliteJdbcFeature implements Feature {
         RuntimeClassInitialization.initializeAtBuildTime(JDBC3DatabaseMetaData.class);
         RuntimeClassInitialization.initializeAtBuildTime(OSInfo.class);
         RuntimeClassInitialization.initializeAtBuildTime(LibraryLoaderUtil.class);
-        RuntimeClassInitialization.initializeAtBuildTime(LoggerFactory.class);
         a.registerReachabilityHandler(
                 this::nativeDbReachable, method(SQLiteJDBCLoader.class, "initialize"));
     }


### PR DESCRIPTION
The logging framework (slf4j) should not be configured to be initialized at build-time:
* It is bad form to dictate native-image configuration for classes that are not our own. This can cause configuration conflicts if either the end-user or the maintainer of the external class have/add their own configuration.
* end-users often configure logging frameworks to either redirect to each other, or have custom formatting rules. Initializing the logging framework at build-time can cause this configuration to be missed and partially or completely ignored.

This PR makes sure the logging framework is again initialized at run-time, by:
* Using in-line declarations of single-use loggers: `org.sqlite.SQLiteJDBCLoader$VersionHolder`
* Creating a `LogHolder` subclass which holds the logger instance, if the parent class is configured to be initialized at build-time. The holder wrapper itself will be initialzed at run-time which delays the logger instantiation to its first use: `org.sqlite.jdbc3.JDBC3DatabaseMetaData$LogHolder` & `org.sqlite.util.OSInfo$LogHolder`
* Although not used in this PR, an alternative is to invert the initialization config of a class like `JDBC3DatabaseMetaData`. The parent class (with static logger instance) would be configured at run-time, and the build-time initialization part would be put in an internal wrapper class which is marked for build-time initialization. An example of where this is already set up like this: `org.sqlite.SQLiteJDBCLoader$VersionHolder`. 