### PR TITLE
Make ConnectionConfig#autoCommit configurable via fake pragma

### DIFF
--- a/src/main/java/org/sqlite/SQLiteConfig.java
+++ b/src/main/java/org/sqlite/SQLiteConfig.java
@@ -535,7 +535,9 @@ public class SQLiteConfig {
 
         // extensions: "fake" pragmas to allow conformance with JDBC
         JDBC_AUTO_COMMIT(
-                "jdbc.auto_commit", "Configure explicit read only transactions", new String[] {"true", "false"}),
+                "jdbc.auto_commit",
+                "Configure explicit read only transactions",
+                new String[] {"true", "false"}),
         JDBC_EXPLICIT_READONLY(
                 "jdbc.explicit_readonly", "Set explicit read only transactions", null);
 

--- a/src/main/java/org/sqlite/SQLiteConfig.java
+++ b/src/main/java/org/sqlite/SQLiteConfig.java
@@ -534,6 +534,8 @@ public class SQLiteConfig {
         PASSWORD("password", "Database password", null),
 
         // extensions: "fake" pragmas to allow conformance with JDBC
+        JDBC_AUTO_COMMIT(
+                "jdbc.auto_commit", "Configure explicit read only transactions", new String[] {"true", "false"}),
         JDBC_EXPLICIT_READONLY(
                 "jdbc.explicit_readonly", "Set explicit read only transactions", null);
 

--- a/src/main/java/org/sqlite/SQLiteConnectionConfig.java
+++ b/src/main/java/org/sqlite/SQLiteConnectionConfig.java
@@ -38,8 +38,8 @@ public class SQLiteConnectionConfig implements Cloneable {
                         pragmaTable.getProperty(
                                 SQLiteConfig.Pragma.TRANSACTION_MODE.pragmaName,
                                 SQLiteConfig.TransactionMode.DEFERRED.name())),
-                pragmaTable.getProperty(
-                        SQLiteConfig.Pragma.JDBC_AUTO_COMMIT.pragmaName, "true")
+                pragmaTable
+                        .getProperty(SQLiteConfig.Pragma.JDBC_AUTO_COMMIT.pragmaName, "true")
                         .equals("true"));
     }
 

--- a/src/main/java/org/sqlite/SQLiteConnectionConfig.java
+++ b/src/main/java/org/sqlite/SQLiteConnectionConfig.java
@@ -38,7 +38,9 @@ public class SQLiteConnectionConfig implements Cloneable {
                         pragmaTable.getProperty(
                                 SQLiteConfig.Pragma.TRANSACTION_MODE.pragmaName,
                                 SQLiteConfig.TransactionMode.DEFERRED.name())),
-                true);
+                pragmaTable.getProperty(
+                        SQLiteConfig.Pragma.JDBC_AUTO_COMMIT.pragmaName,
+                        "true").equals("true"));
     }
 
     public SQLiteConnectionConfig(

--- a/src/main/java/org/sqlite/SQLiteConnectionConfig.java
+++ b/src/main/java/org/sqlite/SQLiteConnectionConfig.java
@@ -39,8 +39,8 @@ public class SQLiteConnectionConfig implements Cloneable {
                                 SQLiteConfig.Pragma.TRANSACTION_MODE.pragmaName,
                                 SQLiteConfig.TransactionMode.DEFERRED.name())),
                 pragmaTable.getProperty(
-                        SQLiteConfig.Pragma.JDBC_AUTO_COMMIT.pragmaName,
-                        "true").equals("true"));
+                        SQLiteConfig.Pragma.JDBC_AUTO_COMMIT.pragmaName, "true")
+                        .equals("true"));
     }
 
     public SQLiteConnectionConfig(


### PR DESCRIPTION
## Problem

I am using Kotlin's SQL Framework https://github.com/JetBrains/Exposed with sqlite-jdbc.
```kotlin
import org.jetbrains.exposed.sql.Database
import org.jetbrains.exposed.sql.transactions.transaction
(snip)

val sqLiteConfig = SQLiteConfig()
val ds = SQLiteDataSource(sqLiteConfig)
val database = Database.connect(ds)

import org.jetbrains.exposed.sql.transactions.transaction
import org.sqlite.SQLiteErrorCode
import org.sqlite.SQLiteException
import java.time.temporal.Temporal

transaction(db) {
  connection.autoCommit = false
  // do something with DB
}
```

I want to disable auto-commit for better performance, but it appears that it is not configurable via SQLiteConfig nor SQLiteDataSource.
SQLiteConnectionConfig offers `setAutoCommit`, but `SQLiteConfig#defaultConnectionConfig` always use `autoCommit = true`.
https://github.com/xerial/sqlite-jdbc/blob/263c296f0057b1de9d758fbdef5ccfd2762add26/src/main/java/org/sqlite/SQLiteConnectionConfig.java#L21

One can specify `connection.autoCommit = false` in `transaction { ... }` DSL, but it is error-prone because one might forget.

## Proposal

This PR adds "fake" pragma `jdbc.auto_commit`, so auto-commit can be configurable via SQLiteConfig.

```kotlin
val prop = new Properties()
prop.setProperty(SQLiteConfig.Pragma.JDBC_AUTO_COMMIT.pragmaName, "true")
val sqLiteConfig = SQLiteConfig(prop)
val ds = SQLiteDataSource(sqLiteConfig)
val database = Database.connect(ds)
```
