### PR TITLE
feat(jdbc): reintroduce improved support for Statement#getGeneratedKeys

### DIFF
--- a/src/main/java/org/sqlite/core/CoreStatement.java
+++ b/src/main/java/org/sqlite/core/CoreStatement.java
@@ -193,8 +193,7 @@ public abstract class CoreStatement implements Codes {
         // up a new result set without any contents by issuing a query with a false where condition
         if (generatedKeysRs == null) {
             generatedKeysStat = conn.createStatement();
-            generatedKeysRs =
-                    generatedKeysStat.executeQuery("SELECT 1 WHERE 1 = 2;");
+            generatedKeysRs = generatedKeysStat.executeQuery("SELECT 1 WHERE 1 = 2;");
         }
         return generatedKeysRs;
     }

--- a/src/main/java/org/sqlite/core/CoreStatement.java
+++ b/src/main/java/org/sqlite/core/CoreStatement.java
@@ -18,7 +18,6 @@ package org.sqlite.core;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-
 import org.sqlite.SQLiteConnection;
 import org.sqlite.SQLiteConnectionConfig;
 import org.sqlite.jdbc3.JDBC3Connection;
@@ -156,7 +155,7 @@ public abstract class CoreStatement implements Codes {
     }
 
     protected void clearGeneratedKeys() throws SQLException {
-        if(generatedKeysRs != null && !generatedKeysRs.isClosed()) {
+        if (generatedKeysRs != null && !generatedKeysRs.isClosed()) {
             generatedKeysRs.close();
         }
         generatedKeysRs = null;
@@ -167,20 +166,19 @@ public abstract class CoreStatement implements Codes {
     }
 
     /**
-     * SQLite's last_insert_rowid() function is DB-specific. However, in this implementation
-     * we ensure the Generated Key result set is statement-specific by executing the query
-     * immediately after an insert operation is performed. The caller is simply responsible for
-     * calling updateGeneratedKeys on the statement object right after execute in
-     * a synchronized(connection) block.
+     * SQLite's last_insert_rowid() function is DB-specific. However, in this implementation we
+     * ensure the Generated Key result set is statement-specific by executing the query immediately
+     * after an insert operation is performed. The caller is simply responsible for calling
+     * updateGeneratedKeys on the statement object right after execute in a synchronized(connection)
+     * block.
      */
     public void updateGeneratedKeys() throws SQLException {
         clearGeneratedKeys();
-        if(sql != null && sql.toLowerCase().startsWith("insert")) {
+        if (sql != null && sql.toLowerCase().startsWith("insert")) {
             generatedKeysStat = conn.createStatement();
             generatedKeysRs = generatedKeysStat.executeQuery("SELECT last_insert_rowid();");
         }
     }
-
 
     /**
      * This implementation uses SQLite's last_insert_rowid function to obtain the row ID. It cannot
@@ -193,9 +191,10 @@ public abstract class CoreStatement implements Codes {
         // getGeneratedKeys is required to return an EmptyResult set if the statement
         // did not generate any keys. Thus, if the generateKeysResultSet is NULL, spin
         // up a new result set without any contents by issuing a query with a false where condition
-        if(generatedKeysRs == null) {
+        if (generatedKeysRs == null) {
             generatedKeysStat = conn.createStatement();
-            generatedKeysRs = generatedKeysStat.executeQuery("SELECT last_insert_rowid() WHERE 0 <> 0;");
+            generatedKeysRs =
+                    generatedKeysStat.executeQuery("SELECT last_insert_rowid() WHERE 0 <> 0;");
         }
         return generatedKeysRs;
     }

--- a/src/main/java/org/sqlite/core/CoreStatement.java
+++ b/src/main/java/org/sqlite/core/CoreStatement.java
@@ -194,7 +194,7 @@ public abstract class CoreStatement implements Codes {
         if (generatedKeysRs == null) {
             generatedKeysStat = conn.createStatement();
             generatedKeysRs =
-                    generatedKeysStat.executeQuery("SELECT last_insert_rowid() WHERE 0 <> 0;");
+                    generatedKeysStat.executeQuery("SELECT 1 WHERE 1 = 2;");
         }
         return generatedKeysRs;
     }

--- a/src/main/java/org/sqlite/core/CoreStatement.java
+++ b/src/main/java/org/sqlite/core/CoreStatement.java
@@ -17,6 +17,8 @@ package org.sqlite.core;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
+
 import org.sqlite.SQLiteConnection;
 import org.sqlite.SQLiteConnectionConfig;
 import org.sqlite.jdbc3.JDBC3Connection;
@@ -32,6 +34,9 @@ public abstract class CoreStatement implements Codes {
     protected int batchPos;
     protected Object[] batch = null;
     protected boolean resultsWaiting = false;
+
+    private Statement generatedKeysStat = null;
+    private ResultSet generatedKeysRs = null;
 
     protected CoreStatement(SQLiteConnection c) {
         conn = c;
@@ -148,5 +153,50 @@ public abstract class CoreStatement implements Codes {
         if (index < 1 || index > batch.length) {
             throw new SQLException("Parameter index is invalid");
         }
+    }
+
+    protected void clearGeneratedKeys() throws SQLException {
+        if(generatedKeysRs != null && !generatedKeysRs.isClosed()) {
+            generatedKeysRs.close();
+        }
+        generatedKeysRs = null;
+        if (generatedKeysStat != null && !generatedKeysStat.isClosed()) {
+            generatedKeysStat.close();
+        }
+        generatedKeysStat = null;
+    }
+
+    /**
+     * SQLite's last_insert_rowid() function is DB-specific. However, in this implementation
+     * we ensure the Generated Key result set is statement-specific by executing the query
+     * immediately after an insert operation is performed. The caller is simply responsible for
+     * calling updateGeneratedKeys on the statement object right after execute in
+     * a synchronized(connection) block.
+     */
+    public void updateGeneratedKeys() throws SQLException {
+        clearGeneratedKeys();
+        if(sql != null && sql.toLowerCase().startsWith("insert")) {
+            generatedKeysStat = conn.createStatement();
+            generatedKeysRs = generatedKeysStat.executeQuery("SELECT last_insert_rowid();");
+        }
+    }
+
+
+    /**
+     * This implementation uses SQLite's last_insert_rowid function to obtain the row ID. It cannot
+     * provide multiple values when inserting multiple rows. Suggestion is to use a <a
+     * href=https://www.sqlite.org/lang_returning.html>RETURNING</a> clause instead.
+     *
+     * @see java.sql.Statement#getGeneratedKeys()
+     */
+    public ResultSet getGeneratedKeys() throws SQLException {
+        // getGeneratedKeys is required to return an EmptyResult set if the statement
+        // did not generate any keys. Thus, if the generateKeysResultSet is NULL, spin
+        // up a new result set without any contents by issuing a query with a false where condition
+        if(generatedKeysRs == null) {
+            generatedKeysStat = conn.createStatement();
+            generatedKeysRs = generatedKeysStat.executeQuery("SELECT last_insert_rowid() WHERE 0 <> 0;");
+        }
+        return generatedKeysRs;
     }
 }

--- a/src/main/java/org/sqlite/jdbc3/JDBC3DatabaseMetaData.java
+++ b/src/main/java/org/sqlite/jdbc3/JDBC3DatabaseMetaData.java
@@ -559,7 +559,7 @@ public abstract class JDBC3DatabaseMetaData extends CoreDatabaseMetaData {
 
     /** @see java.sql.DatabaseMetaData#supportsGetGeneratedKeys() */
     public boolean supportsGetGeneratedKeys() {
-        return false;
+        return true;
     }
 
     /** @see java.sql.DatabaseMetaData#supportsGroupBy() */

--- a/src/main/java/org/sqlite/jdbc3/JDBC3PreparedStatement.java
+++ b/src/main/java/org/sqlite/jdbc3/JDBC3PreparedStatement.java
@@ -54,10 +54,13 @@ public abstract class JDBC3PreparedStatement extends CorePreparedStatement {
                 () -> {
                     boolean success = false;
                     try {
-                        resultsWaiting =
-                                conn.getDatabase().execute(JDBC3PreparedStatement.this, batch);
-                        success = true;
-                        updateCount = getDatabase().changes();
+                        synchronized (conn) {
+                            resultsWaiting =
+                                    conn.getDatabase().execute(JDBC3PreparedStatement.this, batch);
+                            updateGeneratedKeys();
+                            success = true;
+                            updateCount = getDatabase().changes();
+                        }
                         return 0 != columnCount;
                     } finally {
                         if (!success && !pointer.isClosed()) pointer.safeRunConsume(DB::reset);
@@ -119,7 +122,13 @@ public abstract class JDBC3PreparedStatement extends CorePreparedStatement {
         }
 
         return this.withConnectionTimeout(
-                () -> conn.getDatabase().executeUpdate(JDBC3PreparedStatement.this, batch));
+                () -> {
+                    synchronized (conn) {
+                        long rc = conn.getDatabase().executeUpdate(JDBC3PreparedStatement.this, batch);
+                        updateGeneratedKeys();
+                        return rc;
+                    }
+                });
     }
 
     /** @see java.sql.PreparedStatement#addBatch() */

--- a/src/main/java/org/sqlite/jdbc3/JDBC3PreparedStatement.java
+++ b/src/main/java/org/sqlite/jdbc3/JDBC3PreparedStatement.java
@@ -124,7 +124,9 @@ public abstract class JDBC3PreparedStatement extends CorePreparedStatement {
         return this.withConnectionTimeout(
                 () -> {
                     synchronized (conn) {
-                        long rc = conn.getDatabase().executeUpdate(JDBC3PreparedStatement.this, batch);
+                        long rc =
+                                conn.getDatabase()
+                                        .executeUpdate(JDBC3PreparedStatement.this, batch);
                         updateGeneratedKeys();
                         return rc;
                     }

--- a/src/main/java/org/sqlite/jdbc3/JDBC3Statement.java
+++ b/src/main/java/org/sqlite/jdbc3/JDBC3Statement.java
@@ -133,7 +133,8 @@ public abstract class JDBC3Statement extends CoreStatement {
                                 changes = db.total_changes();
                                 // directly invokes the exec API to support multiple SQL statements
                                 int statusCode = db._exec(sql);
-                                if (statusCode != SQLITE_OK) throw DB.newSQLException(statusCode, "");
+                                if (statusCode != SQLITE_OK)
+                                    throw DB.newSQLException(statusCode, "");
                                 updateGeneratedKeys();
                                 changes = db.total_changes() - changes;
                             }

--- a/src/main/java/org/sqlite/jdbc3/JDBC3Statement.java
+++ b/src/main/java/org/sqlite/jdbc3/JDBC3Statement.java
@@ -32,6 +32,7 @@ public abstract class JDBC3Statement extends CoreStatement {
 
     /** @see java.sql.Statement#close() */
     public void close() throws SQLException {
+        clearGeneratedKeys();
         internalClose();
     }
 
@@ -49,12 +50,14 @@ public abstract class JDBC3Statement extends CoreStatement {
                     }
 
                     JDBC3Statement.this.sql = sql;
-
-                    conn.getDatabase().prepare(JDBC3Statement.this);
-                    boolean result = exec();
-                    updateCount = getDatabase().changes();
-                    exhaustedResults = false;
-                    return result;
+                    synchronized (conn) {
+                        conn.getDatabase().prepare(JDBC3Statement.this);
+                        boolean result = exec();
+                        updateGeneratedKeys();
+                        updateCount = getDatabase().changes();
+                        exhaustedResults = false;
+                        return result;
+                    }
                 });
     }
 
@@ -126,13 +129,15 @@ public abstract class JDBC3Statement extends CoreStatement {
                         ext.execute(db);
                     } else {
                         try {
-                            changes = db.total_changes();
+                            synchronized (db) {
+                                changes = db.total_changes();
+                                // directly invokes the exec API to support multiple SQL statements
+                                int statusCode = db._exec(sql);
+                                if (statusCode != SQLITE_OK) throw DB.newSQLException(statusCode, "");
+                                updateGeneratedKeys();
+                                changes = db.total_changes() - changes;
+                            }
 
-                            // directly invokes the exec API to support multiple SQL statements
-                            int statusCode = db._exec(sql);
-                            if (statusCode != SQLITE_OK) throw DB.newSQLException(statusCode, "");
-
-                            changes = db.total_changes() - changes;
                         } finally {
                             internalClose();
                         }
@@ -348,17 +353,6 @@ public abstract class JDBC3Statement extends CoreStatement {
                                 + ". "
                                 + "Must be one of FETCH_FORWARD, FETCH_REVERSE, or FETCH_UNKNOWN in java.sql.ResultSet");
         }
-    }
-
-    /**
-     * SQLite's last_insert_rowid() function is DB-specific, not statement specific, and cannot
-     * provide multiple values when inserting multiple rows. Suggestion is to use a <a
-     * href=https://www.sqlite.org/lang_returning.html>RETURNING</a> clause instead.
-     *
-     * @see java.sql.Statement#getGeneratedKeys()
-     */
-    public ResultSet getGeneratedKeys() throws SQLException {
-        throw unsupported();
     }
 
     /**

--- a/src/test/java/org/sqlite/DBMetaDataTest.java
+++ b/src/test/java/org/sqlite/DBMetaDataTest.java
@@ -51,7 +51,6 @@ public class DBMetaDataTest {
     public void getTables() throws SQLException {
         ResultSet rs = meta.getTables(null, null, null, null);
         assertThat(rs).isNotNull();
-
         stat.close();
 
         assertThat(rs.next()).isTrue();

--- a/src/test/java/org/sqlite/PrepStmtTest.java
+++ b/src/test/java/org/sqlite/PrepStmtTest.java
@@ -67,8 +67,13 @@ public class PrepStmtTest {
         assertThat(prep.executeUpdate()).isEqualTo(1);
         prep.setInt(1, 7);
         assertThat(prep.executeUpdate()).isEqualTo(1);
-        prep.close();
 
+        ResultSet rsgk = prep.getGeneratedKeys();
+        assertThat(rsgk.next()).isTrue();
+        assertThat(rsgk.getInt(1)).isEqualTo(3);
+        rsgk.close();
+
+        prep.close();
         // check results with normal statement
         ResultSet rs = stat.executeQuery("select sum(c1) from s1;");
         assertThat(rs.next()).isTrue();

--- a/src/test/java/org/sqlite/StatementTest.java
+++ b/src/test/java/org/sqlite/StatementTest.java
@@ -330,15 +330,15 @@ public class StatementTest {
     @Test
     public void getGeneratedKeysIsStatementSpecific() throws SQLException {
         /* this test ensures that the results of getGeneratedKeys are tied to
-           a specific statement. To verify this, we create two separate Statement
-           objects and then execute inserts on both. We then make getGeneratedKeys()
-           calls and verify that the two separate expected values are returned.
+          a specific statement. To verify this, we create two separate Statement
+          objects and then execute inserts on both. We then make getGeneratedKeys()
+          calls and verify that the two separate expected values are returned.
 
-           Note that the old implementation of getGeneratedKeys was called lazily, so
-           the result of both getGeneratedKeys calls would be the same value, the row ID
-           of the last insert on the connection. As a result it was unsafe to use
-           with multiple statements or in a multithreaded application.
-         */
+          Note that the old implementation of getGeneratedKeys was called lazily, so
+          the result of both getGeneratedKeys calls would be the same value, the row ID
+          of the last insert on the connection. As a result it was unsafe to use
+          with multiple statements or in a multithreaded application.
+        */
         stat.executeUpdate("create table t1 (c1 integer primary key, v);");
 
         ResultSet rs1;

--- a/src/test/java/org/sqlite/StatementTest.java
+++ b/src/test/java/org/sqlite/StatementTest.java
@@ -307,8 +307,61 @@ public class StatementTest {
         stat.executeUpdate("create table t1 (c1 integer primary key, v);");
         stat.executeUpdate("insert into t1 (v) values ('red');");
 
-        assertThatExceptionOfType(SQLFeatureNotSupportedException.class)
-                .isThrownBy(() -> stat.getGeneratedKeys());
+        rs = stat.getGeneratedKeys();
+        assertThat(rs.next()).isTrue();
+        assertThat(rs.getInt(1)).isEqualTo(1);
+        rs.close();
+        stat.executeUpdate("insert into t1 (v) values ('blue');");
+        rs = stat.getGeneratedKeys();
+        assertThat(rs.next()).isTrue();
+        assertThat(rs.getInt(1)).isEqualTo(2);
+        rs.close();
+
+        // generated keys are now attached to the statement. calling getGeneratedKeys
+        // on a statement that has not generated any should return an empty result set
+        stat.close();
+        Statement stat2 = conn.createStatement();
+        rs = stat2.getGeneratedKeys();
+        assertThat(rs).isNotNull();
+        assertThat(rs.next()).isFalse();
+        stat2.close();
+    }
+
+    @Test
+    public void getGeneratedKeysIsStatementSpecific() throws SQLException {
+        /* this test ensures that the results of getGeneratedKeys are tied to
+           a specific statement. To verify this, we create two separate Statement
+           objects and then execute inserts on both. We then make getGeneratedKeys()
+           calls and verify that the two separate expected values are returned.
+
+           Note that the old implementation of getGeneratedKeys was called lazily, so
+           the result of both getGeneratedKeys calls would be the same value, the row ID
+           of the last insert on the connection. As a result it was unsafe to use
+           with multiple statements or in a multithreaded application.
+         */
+        stat.executeUpdate("create table t1 (c1 integer primary key, v);");
+
+        ResultSet rs1;
+        Statement stat1 = conn.createStatement();
+        ResultSet rs2;
+        Statement stat2 = conn.createStatement();
+
+        stat1.executeUpdate("insert into t1 (v) values ('red');");
+        stat2.executeUpdate("insert into t1 (v) values ('blue');");
+
+        rs2 = stat2.getGeneratedKeys();
+        rs1 = stat1.getGeneratedKeys();
+
+        assertThat(rs1.next()).isTrue();
+        assertThat(rs1.getInt(1)).isEqualTo(1);
+        rs1.close();
+
+        assertThat(rs2.next()).isTrue();
+        assertThat(rs2.getInt(1)).isEqualTo(2);
+        rs2.close();
+
+        stat1.close();
+        stat2.close();
     }
 
     @Test


### PR DESCRIPTION
Hello @gotson,

Over in https://github.com/xerial/sqlite-jdbc/issues/1018#issuecomment-1813516287 you mentioned that you'd be willing to look at a PR that restores getGeneratedKeys functionality if it could resolve the safety issues originally reported in #329. 

This PR seeks to do that by adding back support for Statement#getGeneratedKeys with a new implementation that tightly scopes the generated keys to the Statement object. This makes it safe to use in an interleaved manner, across threads, and with multiple Statements.

In the interest of transparency, this PR does not address tracking keys for multiple inserts on the same statement (#468). However, that functionality was never previously available. That it could potentially be added in future enhancements to this model if it became a requirement.

Restoring this functionality would be a huge benefit to the users of this JDBC driver. Many applications and integrations were adversely affected by the removal of the basic getGeneratedKeys functionality that they came to depend on it over the past 16 years. This PR should restore the core functionality with critical improvements to scope and safety.

Please let me know if you have any questions or suggestions for improvements. Thank you for your consideration.