### PR TITLE
perf: CoreStatement uses optimize regex for generated key matches

### DIFF
--- a/src/main/java/org/sqlite/core/CoreStatement.java
+++ b/src/main/java/org/sqlite/core/CoreStatement.java
@@ -40,9 +40,9 @@ public abstract class CoreStatement implements Codes {
 
     // pattern for matching insert statements of the general format starting with INSERT or REPLACE.
     // CTEs used prior to the insert or replace keyword are also be permitted.
-    private final Pattern insertPattern =
+    private static final Pattern INSERT_PATTERN =
             Pattern.compile(
-                    "^(with\\s+.+\\(.+?\\))*\\s*(insert|replace)",
+                    "^\\s*(?:with\\s+.+\\(.+?\\))*\\s*(?:insert|replace)\\s*",
                     Pattern.DOTALL | Pattern.CASE_INSENSITIVE);
 
     protected CoreStatement(SQLiteConnection c) {
@@ -182,7 +182,7 @@ public abstract class CoreStatement implements Codes {
      */
     public void updateGeneratedKeys() throws SQLException {
         clearGeneratedKeys();
-        if (sql != null && insertPattern.matcher(sql.trim().toLowerCase()).find()) {
+        if (sql != null && INSERT_PATTERN.matcher(sql).find()) {
             generatedKeysStat = conn.createStatement();
             generatedKeysRs = generatedKeysStat.executeQuery("SELECT last_insert_rowid();");
         }

--- a/src/test/java/org/sqlite/StatementTest.java
+++ b/src/test/java/org/sqlite/StatementTest.java
@@ -333,8 +333,8 @@ public class StatementTest {
 
         // test INSERT with common table expression
         stat.executeUpdate(
-                "with colors as (select 'green' as color)\n"
-                        + "insert into t1 (v) select color from colors;");
+                "  WITH colors as (select 'green' as color) \n"
+                        + "INSERT into t1 (v) select color from colors;");
         rs = stat.getGeneratedKeys();
         assertThat(rs.next()).isTrue();
         assertThat(rs.getInt(1)).isEqualTo(3);


### PR DESCRIPTION
While profiling some software that makes heavy use of prepared statements and SQLite, I noticed that each call to `java.sql.Connection#prepareStatement(java.lang.String)` ended up compiling a regex pattern as part of `org.sqlite.core.CoreStatement.<init>(SQLiteConnection)` construction. This appears to be a recent addition as part of https://github.com/xerial/sqlite-jdbc/pull/1056  with example call trace showing up as over 75% of total allocations in JFR:

<img width="1135" alt="image" src="https://github.com/xerial/sqlite-jdbc/assets/54594/f5b5d452-f21c-4bf0-a8d6-beb8f5640321">

Because JDK `Pattern` instances are immutable and thread-safe, we can compile the regex on `CoreStatement` class load to a static field for reuse, and adjust the regex to avoid additional possible allocations from trimming and converting the SQL to lower case, as well as use non-capturing groups to avoid `Pattern#matcher` allocating the `int[]` arrays associated with capture groups.