### PR TITLE
build: use BC signer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,8 +201,6 @@ jobs:
           server-id: ossrh # Value of the distributionManagement/repository/id field of the pom.xml
           server-username: MAVEN_CENTRAL_USERNAME # env variable for username in deploy (1)
           server-password: MAVEN_CENTRAL_PASSWORD # env variable for token in deploy (2)
-          gpg-private-key: ${{ secrets.GPG_KEY }} # Value of the GPG private key to import
-          gpg-passphrase: MAVEN_CENTRAL_GPG_PASSPHRASE # env variable for GPG private key passphrase (3)
       - name: Get Project Version
         run: |
           echo "PROJECT_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)" | tee -a $GITHUB_ENV
@@ -224,11 +222,12 @@ jobs:
       # The sonatype maven plugin will decide the right destination depending on whether the project is SNAPSHOT or not
       - name: Publish to Apache Maven Central
         if: github.event_name == 'push' || inputs.push_maven
-        run: mvn --batch-mode --no-transfer-progress deploy -P release -DskipTests
+        run: mvn --batch-mode --no-transfer-progress deploy -P release -DskipTests -Dgpg.signer=bc
         env:
           MAVEN_CENTRAL_USERNAME: ${{ secrets.SONATYPE_USERNAME }} # must be the same env variable name as (1)
           MAVEN_CENTRAL_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }} # must be the same env variable name as (2)
-          MAVEN_CENTRAL_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }} # must be the same env variable name as (3)
+          MAVEN_GPG_KEY: ${{ secrets.GPG_KEY }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
       - name: Release commit and push
         if: inputs.perform_release
         uses: EndBug/add-and-commit@v9

--- a/pom.xml
+++ b/pom.xml
@@ -284,14 +284,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>3.1.0</version>
-                        <configuration>
-                            <!-- Prevent gpg from using pinentry programs -->
-                            <gpgArguments>
-                                <arg>--pinentry-mode</arg>
-                                <arg>loopback</arg>
-                            </gpgArguments>
-                        </configuration>
+                        <version>3.2.0</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>


### PR DESCRIPTION
Changes:
* upgrade to 3.2.0 GPG plugin
* do NOT import key in home of runner (and leave it there once job done?)
* instead, make them both env variables
* and on CI force BC signer

This leaves GPG on workstation work unchanged.

Related to https://issues.apache.org/jira/browse/MGPG-90