### PR TITLE
Do not print the error message when failed to delete the old native lib.

### DIFF
--- a/src/main/java/org/sqlite/SQLiteJDBCLoader.java
+++ b/src/main/java/org/sqlite/SQLiteJDBCLoader.java
@@ -99,9 +99,8 @@ public class SQLiteJDBCLoader {
                                 Path lckFile = Paths.get(nativeLib + LOCK_EXT);
                                 if (Files.notExists(lckFile)) {
                                     try {
-                                        Files.delete(nativeLib);
+                                        Files.deleteIfExists(nativeLib);
                                     } catch (Exception e) {
-                                        logger.error("Failed to delete old native lib", e);
                                     }
                                 }
                             });


### PR DESCRIPTION
There is no harm not deleting the old lib but the error message is quite annoying.

Thanks,

Fengchao