### PR TITLE
build(deps): bump com.tngtech.archunit:archunit-junit5 from 1.2.1 to 1.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>5.10.2</junit.version>
         <surefire.version>3.2.5</surefire.version>
+        <archunit.version>1.3.0</archunit.version>
         <graalvm.version>24.0.0</graalvm.version>
         <java9.sourceDirectory>${project.basedir}/src/main/java9</java9.sourceDirectory>
     </properties>
@@ -351,15 +352,6 @@
                         <configuration>
                             <fallback>false</fallback>
                             <verbose>true</verbose>
-                            <buildArgs>
-                                <!--
-                                ArchUnit tests don't run in native-image tests.
-                                Remove the ArchUnit JUnit Engine from the ServiceLoader.
-                                -->
-                                <buildArg>
-                                    -H:ServiceLoaderFeatureExcludeServiceProviders=com.tngtech.archunit.junit.internal.ArchUnitTestEngine
-                                </buildArg>
-                            </buildArgs>
                         </configuration>
                     </plugin>
 
@@ -371,13 +363,30 @@
                             <excludes>
                                 <!--  Cannot run in native mode, classes under test cannot be found, class path is empty  -->
                                 <exclude>**/MultipleClassLoaderTest.java</exclude>
-                                <!--  Not needed  -->
-                                <exclude>**/architecture/*.java</exclude>
                             </excludes>
                         </configuration>
                     </plugin>
                 </plugins>
             </build>
+
+            <dependencies>
+                <dependency>
+                    <groupId>com.tngtech.archunit</groupId>
+                    <artifactId>archunit-junit5</artifactId>
+                    <version>${archunit.version}</version>
+                    <scope>test</scope>
+                    <exclusions>
+                        <!--
+                        ArchUnit tests don't run in native-image tests.
+                        Remove the ArchUnit JUnit Engine entirely from the dependency graph thus from the ServiceLoader.
+                        -->
+                        <exclusion>
+                            <groupId>com.tngtech.archunit</groupId>
+                            <artifactId>archunit-junit5-engine</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>native-exported</id>
@@ -451,7 +460,7 @@
         <dependency>
             <groupId>com.tngtech.archunit</groupId>
             <artifactId>archunit-junit5</artifactId>
-            <version>1.2.1</version>
+            <version>${archunit.version}</version>
             <scope>test</scope>
         </dependency>
         <!--   Required by archunit     -->


### PR DESCRIPTION
The ArchUnit Junit5 TestEngine implementation is still initialized by the service loader to discover the available tests before building the native test binary. Removing the engine entirely for native-image tests resolves the issues and allows for removal of existing workarounds to exclude ArchUnit tests.

fixes #1097