### PR TITLE
fix(jdbc): generated columns with stored in SQLite are not marked as generated

### DIFF
--- a/src/main/java/org/sqlite/jdbc3/JDBC3DatabaseMetaData.java
+++ b/src/main/java/org/sqlite/jdbc3/JDBC3DatabaseMetaData.java
@@ -1078,7 +1078,7 @@ public abstract class JDBC3DatabaseMetaData extends CoreDatabaseMetaData {
                             colType = colType.substring(0, iStartOfDimension).trim();
                         }
 
-                        int colGenerated = "2".equals(colHidden) ? 1 : 0;
+                        int colGenerated = Arrays.binarySearch(new String[] {"2", "3"}, colHidden) >= 0 ? 1 : 0;
 
                         sql.append("select ")
                                 .append(i + 1)

--- a/src/main/java/org/sqlite/jdbc3/JDBC3DatabaseMetaData.java
+++ b/src/main/java/org/sqlite/jdbc3/JDBC3DatabaseMetaData.java
@@ -1078,7 +1078,10 @@ public abstract class JDBC3DatabaseMetaData extends CoreDatabaseMetaData {
                             colType = colType.substring(0, iStartOfDimension).trim();
                         }
 
-                        int colGenerated = Arrays.binarySearch(new String[] {"2", "3"}, colHidden) >= 0 ? 1 : 0;
+                        int colGenerated =
+                                Arrays.binarySearch(new String[] {"2", "3"}, colHidden) >= 0
+                                        ? 1
+                                        : 0;
 
                         sql.append("select ")
                                 .append(i + 1)

--- a/src/main/java/org/sqlite/jdbc3/JDBC3DatabaseMetaData.java
+++ b/src/main/java/org/sqlite/jdbc3/JDBC3DatabaseMetaData.java
@@ -1078,10 +1078,10 @@ public abstract class JDBC3DatabaseMetaData extends CoreDatabaseMetaData {
                             colType = colType.substring(0, iStartOfDimension).trim();
                         }
 
-                        int colGenerated =
-                                Arrays.binarySearch(new String[] {"2", "3"}, colHidden) >= 0
-                                        ? 1
-                                        : 0;
+                        int colGenerated = 0;
+                        if ("2".equals(colHidden) || "3".equals(colHidden)) {
+                            colGenerated = 1;
+                        }
 
                         sql.append("select ")
                                 .append(i + 1)

--- a/src/test/java/org/sqlite/DBMetaDataTest.java
+++ b/src/test/java/org/sqlite/DBMetaDataTest.java
@@ -492,12 +492,17 @@ public class DBMetaDataTest {
     }
 
     @Test
-    @DisplayName("Issue #1132 - Generated columns with stored in SQLite are not marked as generated")
+    @DisplayName(
+            "Issue #1132 - Generated columns with stored in SQLite are not marked as generated")
     public void getColumnsIncludingGeneratedStored() throws SQLException {
-        stat.executeUpdate("create table foo(" + "\n"
-            + "  id integer primary key," + "\n"
-            + "  bar int not null generated always as (id + 1) stored" + "\n"
-            + ");");
+        stat.executeUpdate(
+                "create table foo("
+                        + "\n"
+                        + "  id integer primary key,"
+                        + "\n"
+                        + "  bar int not null generated always as (id + 1) stored"
+                        + "\n"
+                        + ");");
 
         ResultSet rs = meta.getColumns(null, null, "foo", "%");
         assertThat(rs.next()).isTrue();

--- a/src/test/java/org/sqlite/DBMetaDataTest.java
+++ b/src/test/java/org/sqlite/DBMetaDataTest.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import java.util.Properties;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledInNativeImage;
@@ -486,6 +487,24 @@ public class DBMetaDataTest {
         assertThat(rs.getString(24)).as("first column is not generated").isEqualTo("NO");
         assertThat(rs.next()).isTrue();
         assertThat(rs.getString(4)).as("second column is named 'j'").isEqualTo("j");
+        assertThat(rs.getString(24)).as("second column is generated").isEqualTo("YES");
+        assertThat(rs.next()).isFalse();
+    }
+
+    @Test
+    @DisplayName("Issue #1132 - Generated columns with stored in SQLite are not marked as generated")
+    public void getColumnsIncludingGeneratedStored() throws SQLException {
+        stat.executeUpdate("create table foo(" + "\n"
+            + "  id integer primary key," + "\n"
+            + "  bar int not null generated always as (id + 1) stored" + "\n"
+            + ");");
+
+        ResultSet rs = meta.getColumns(null, null, "foo", "%");
+        assertThat(rs.next()).isTrue();
+        assertThat(rs.getString(4)).as("first column is named 'id'").isEqualTo("id");
+        assertThat(rs.getString(24)).as("first column is generated").isEqualTo("NO");
+        assertThat(rs.next()).isTrue();
+        assertThat(rs.getString(4)).as("second column is named 'bar'").isEqualTo("bar");
         assertThat(rs.getString(24)).as("second column is generated").isEqualTo("YES");
         assertThat(rs.next()).isFalse();
     }


### PR DESCRIPTION
Fixes #1132 - Generated columns with stored in SQLite are not marked as generated