### PR TITLE
fix(native-image): add support for --strict-image-heap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        java: [ '17', '21' ]
+        java: [ '17', '21', '22' ]
         profiles: ['native', 'native,native-exported']
     runs-on: ${{ matrix.os }}
     steps:

--- a/pom.xml
+++ b/pom.xml
@@ -352,6 +352,10 @@
                         <configuration>
                             <fallback>false</fallback>
                             <verbose>true</verbose>
+                            <buildArgs>
+                                <!-- required to allow junit-pioneer to compile with strict image heap enabled -->
+                                <arg>--initialize-at-build-time=org.junitpioneer.jupiter.issue.IssueExtensionExecutionListener</arg>
+                            </buildArgs>
                         </configuration>
                     </plugin>
 

--- a/src/main/java9/org/sqlite/nativeimage/SqliteJdbcFeature.java
+++ b/src/main/java9/org/sqlite/nativeimage/SqliteJdbcFeature.java
@@ -10,6 +10,7 @@ import org.sqlite.core.NativeDB;
 import org.sqlite.jdbc3.JDBC3DatabaseMetaData;
 import org.sqlite.util.LibraryLoaderUtil;
 import org.sqlite.util.OSInfo;
+import org.sqlite.util.ProcessRunner;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -27,6 +28,7 @@ public class SqliteJdbcFeature implements Feature {
         RuntimeClassInitialization.initializeAtBuildTime(SQLiteJDBCLoader.VersionHolder.class);
         RuntimeClassInitialization.initializeAtBuildTime(JDBC3DatabaseMetaData.class);
         RuntimeClassInitialization.initializeAtBuildTime(OSInfo.class);
+        RuntimeClassInitialization.initializeAtBuildTime(ProcessRunner.class);
         RuntimeClassInitialization.initializeAtBuildTime(LibraryLoaderUtil.class);
         a.registerReachabilityHandler(
                 this::nativeDbReachable, method(SQLiteJDBCLoader.class, "initialize"));


### PR DESCRIPTION
GraalVM for JDK 22 [(release notes)](https://www.graalvm.org/release-notes/JDK_22/#native-image) enables the `--strict-image-heap` option by default, which requires all objects stored in the native-image heap to be marked as build-time initialized.

Issue can be reproduced on GraalVM for JDK 21 by adding `--strict-image-heap` as native-image cli argument. This is however not a future-proof testing setup as the option will be removed in a future GraalVM release. As form of validation, GraalVM for JDK 22 was added to the test suite.

Proof this does fix the issue:
* First commit adds GraalVM for JDK 22 to the test suite, which fails the suite on the reported `--initialize-at-build-time=org.sqlite.util.ProcessRunner` error.
* Second commit restores the CI to green.

fixes #1158