### PR TITLE
Add JUnit 5.12 and GraalVM for JDK 24 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        java: [ '17', '21', '22' ]
+        java: [ '17', '21', '24' ]
         profiles: ['native', 'native,native-exported']
     runs-on: ${{ matrix.os }}
     steps:

--- a/pom.xml
+++ b/pom.xml
@@ -355,6 +355,15 @@
                             <buildArgs>
                                 <!-- required to allow junit-pioneer to compile with strict image heap enabled -->
                                 <arg>--initialize-at-build-time=org.junitpioneer.jupiter.issue.IssueExtensionExecutionListener</arg>
+                                <!--
+                                Issues with JUnit support should be largely resolved by https://github.com/graalvm/native-build-tools/issues/613
+                                These are only necessary for GraalVM for JDK 22+ as this has the Strict Image Heap enabled by default,
+                                and should be removed when aforementioned issue is released in a new buildtools release.
+                                -->
+                                <arg>--initialize-at-build-time=org.junit.jupiter.engine.descriptor.ExclusiveResourceCollector$DefaultExclusiveResourceCollector</arg>
+                                <arg>--initialize-at-build-time=org.junit.jupiter.api.parallel.ResourceLock</arg>
+                                <arg>--initialize-at-build-time=org.junit.jupiter.api.parallel.ResourceLockTarget</arg>
+                                <arg>--initialize-at-build-time=org.junit.jupiter.api.parallel.ResourceAccessMode</arg>
                             </buildArgs>
                         </configuration>
                     </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <junit.version>5.11.4</junit.version>
+        <junit.version>5.12.1</junit.version>
         <surefire.version>3.5.2</surefire.version>
         <archunit.version>1.4.0</archunit.version>
         <graalvm.version>24.1.2</graalvm.version>
@@ -431,7 +431,6 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -476,4 +475,15 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>${junit.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 </project>

--- a/src/test/resources/META-INF/native-image/org.xerial/sqlite-jdbc/reachability-metadata.json
+++ b/src/test/resources/META-INF/native-image/org.xerial/sqlite-jdbc/reachability-metadata.json
@@ -1,0 +1,35 @@
+{
+  "comment": "New reachability metadata format introduced in GraalVM for JDK 23, this merges the other *-config.json files into one: https://www.graalvm.org/latest/reference-manual/native-image/metadata/",
+  "resources": [
+    {
+      "glob": "org/sqlite/*.jar"
+    },
+    {
+      "glob": "org/sqlite/*.db"
+    },
+    {
+      "module": "java.sql.rowset",
+      "glob": "javax/sql/rowset/rowset.properties"
+    }
+  ],
+  "bundles": [
+    {
+      "name": "com.sun.rowset.RowSetResourceBundle"
+    }
+  ],
+  "reflection": [
+    {
+      "type": "com.sun.rowset.providers.RIOptimisticProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "java.sql.Types",
+      "allPublicFields": true
+    }
+  ]
+}


### PR DESCRIPTION
* Test against GraalVM for JDK 24.
* Fix failures with JUnit 5.12 caused by missing build-time initialization.