### PR TITLE
refactor: Centralize all Pattern constants into `PatternConstants`

### DIFF
--- a/src/main/java/org/sqlite/ExtendedCommand.java
+++ b/src/main/java/org/sqlite/ExtendedCommand.java
@@ -14,6 +14,9 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.sqlite.core.DB;
 
+import static org.sqlite.util.PatternConstants.BACKUP_CMD;
+import static org.sqlite.util.PatternConstants.RESTORE_CMD;
+
 /**
  * parsing SQLite specific extension of SQL command
  *
@@ -73,11 +76,6 @@ public class ExtendedCommand {
             this.destFile = destFile;
         }
 
-        private static Pattern backupCmd =
-                Pattern.compile(
-                        "backup(\\s+(\"[^\"]*\"|'[^\']*\'|\\S+))?\\s+to\\s+(\"[^\"]*\"|'[^\']*\'|\\S+)",
-                        Pattern.CASE_INSENSITIVE);
-
         /**
          * Parses SQLite database backup command and creates a BackupCommand object.
          *
@@ -87,7 +85,7 @@ public class ExtendedCommand {
          */
         public static BackupCommand parse(String sql) throws SQLException {
             if (sql != null) {
-                Matcher m = backupCmd.matcher(sql);
+                Matcher m = BACKUP_CMD.matcher(sql);
                 if (m.matches()) {
                     String dbName = removeQuotation(m.group(2));
                     String dest = removeQuotation(m.group(3));
@@ -111,11 +109,7 @@ public class ExtendedCommand {
     public static class RestoreCommand implements SQLExtension {
         public final String targetDB;
         public final String srcFile;
-        private static Pattern restoreCmd =
-                Pattern.compile(
-                        "restore(\\s+(\"[^\"]*\"|'[^\']*\'|\\S+))?\\s+from\\s+(\"[^\"]*\"|'[^\']*\'|\\S+)",
-                        Pattern.CASE_INSENSITIVE);
-
+        
         /**
          * Constructs a RestoreCommand instance that restores the database from a given source file.
          *
@@ -136,7 +130,7 @@ public class ExtendedCommand {
          */
         public static RestoreCommand parse(String sql) throws SQLException {
             if (sql != null) {
-                Matcher m = restoreCmd.matcher(sql);
+                Matcher m = RESTORE_CMD.matcher(sql);
                 if (m.matches()) {
                     String dbName = removeQuotation(m.group(2));
                     String dest = removeQuotation(m.group(3));

--- a/src/main/java/org/sqlite/core/CoreDatabaseMetaData.java
+++ b/src/main/java/org/sqlite/core/CoreDatabaseMetaData.java
@@ -182,20 +182,6 @@ public abstract class CoreDatabaseMetaData implements DatabaseMetaData {
         return buf.toString();
     }
 
-    // inner classes
-
-    /** Pattern used to extract column order for an unnamed primary key. */
-    protected static final Pattern PK_UNNAMED_PATTERN =
-            Pattern.compile(
-                    ".*\\sPRIMARY\\s+KEY\\s+\\((.*?,+.*?)\\).*",
-                    Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
-
-    /** Pattern used to extract a named primary key. */
-    protected static final Pattern PK_NAMED_PATTERN =
-            Pattern.compile(
-                    ".*\\sCONSTRAINT\\s+(.*?)\\s+PRIMARY\\s+KEY\\s+\\((.*?)\\).*",
-                    Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
-
     /** @see java.lang.Object#finalize() */
     protected void finalize() throws Throwable {
         close();

--- a/src/main/java/org/sqlite/core/CoreStatement.java
+++ b/src/main/java/org/sqlite/core/CoreStatement.java
@@ -24,6 +24,8 @@ import org.sqlite.SQLiteConnectionConfig;
 import org.sqlite.jdbc3.JDBC3Connection;
 import org.sqlite.jdbc4.JDBC4ResultSet;
 
+import static org.sqlite.util.PatternConstants.INSERT_PATTERN;
+
 public abstract class CoreStatement implements Codes {
     public final SQLiteConnection conn;
     protected final CoreResultSet rs;
@@ -37,13 +39,6 @@ public abstract class CoreStatement implements Codes {
 
     private Statement generatedKeysStat = null;
     private ResultSet generatedKeysRs = null;
-
-    // pattern for matching insert statements of the general format starting with INSERT or REPLACE.
-    // CTEs used prior to the insert or replace keyword are also be permitted.
-    private static final Pattern INSERT_PATTERN =
-            Pattern.compile(
-                    "^\\s*(?:with\\s+.+\\(.+?\\))*\\s*(?:insert|replace)\\s*",
-                    Pattern.DOTALL | Pattern.CASE_INSENSITIVE);
 
     protected CoreStatement(SQLiteConnection c) {
         conn = c;

--- a/src/main/java/org/sqlite/date/FastDateParser.java
+++ b/src/main/java/org/sqlite/date/FastDateParser.java
@@ -37,6 +37,8 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static org.sqlite.util.PatternConstants.FORMAT_PATTERN;
+
 /**
  * FastDateParser is a fast and thread-safe version of {@link java.text.SimpleDateFormat}.
  *
@@ -151,7 +153,7 @@ public class FastDateParser implements DateParser, Serializable {
         final StringBuilder regex = new StringBuilder();
         final List<Strategy> collector = new ArrayList<Strategy>();
 
-        final Matcher patternMatcher = formatPattern.matcher(pattern);
+        final Matcher patternMatcher = FORMAT_PATTERN.matcher(pattern);
         if (!patternMatcher.lookingAt()) {
             throw new IllegalArgumentException(
                     "Illegal pattern character '"
@@ -479,11 +481,6 @@ public class FastDateParser implements DateParser, Serializable {
          */
         abstract boolean addRegex(FastDateParser parser, StringBuilder regex);
     }
-
-    /** A <code>Pattern</code> to parse the user supplied SimpleDateFormat pattern */
-    private static final Pattern formatPattern =
-            Pattern.compile(
-                    "D+|E+|F+|G+|H+|K+|M+|S+|W+|X+|Z+|a+|d+|h+|k+|m+|s+|w+|y+|z+|''|'[^']++(''[^']*+)*+'|[^'A-Za-z]++");
 
     /**
      * Obtain a Strategy given a field from a SimpleDateFormat pattern

--- a/src/main/java/org/sqlite/jdbc3/JDBC3DatabaseMetaData.java
+++ b/src/main/java/org/sqlite/jdbc3/JDBC3DatabaseMetaData.java
@@ -30,6 +30,8 @@ import org.sqlite.util.LoggerFactory;
 import org.sqlite.util.QueryUtils;
 import org.sqlite.util.StringUtils;
 
+import static org.sqlite.util.PatternConstants.*;
+
 public abstract class JDBC3DatabaseMetaData extends CoreDatabaseMetaData {
 
     private static String driverName;
@@ -840,11 +842,6 @@ public abstract class JDBC3DatabaseMetaData extends CoreDatabaseMetaData {
 
         return getColumnPrivileges.executeQuery();
     }
-
-    // Column type patterns
-    protected static final Pattern TYPE_INTEGER = Pattern.compile(".*(INT|BOOL).*");
-    protected static final Pattern TYPE_VARCHAR = Pattern.compile(".*(CHAR|CLOB|TEXT|BLOB).*");
-    protected static final Pattern TYPE_FLOAT = Pattern.compile(".*(REAL|FLOA|DOUB|DEC|NUM).*");
 
     /**
      * @see java.sql.DatabaseMetaData#getColumns(java.lang.String, java.lang.String,
@@ -1951,19 +1948,6 @@ public abstract class JDBC3DatabaseMetaData extends CoreDatabaseMetaData {
         throw new SQLFeatureNotSupportedException("Not yet implemented by SQLite JDBC driver");
     }
 
-    // inner classes
-
-    /** Pattern used to extract column order for an unnamed primary key. */
-    protected static final Pattern PK_UNNAMED_PATTERN =
-            Pattern.compile(
-                    ".*PRIMARY\\s+KEY\\s*\\((.*?)\\).*", Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
-
-    /** Pattern used to extract a named primary key. */
-    protected static final Pattern PK_NAMED_PATTERN =
-            Pattern.compile(
-                    ".*CONSTRAINT\\s*(.*?)\\s*PRIMARY\\s+KEY\\s*\\((.*?)\\).*",
-                    Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
-
     /** Parses the sqlite_schema table for a table's primary key */
     class PrimaryKeyFinder {
         /** The table name. */
@@ -2044,12 +2028,6 @@ public abstract class JDBC3DatabaseMetaData extends CoreDatabaseMetaData {
     }
 
     class ImportedKeyFinder {
-
-        /** Pattern used to extract a named primary key. */
-        private final Pattern FK_NAMED_PATTERN =
-                Pattern.compile(
-                        "CONSTRAINT\\s*\"?([A-Za-z_][A-Za-z\\d_]*)?\"?\\s*FOREIGN\\s+KEY\\s*\\((.*?)\\)",
-                        Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
 
         private final String fkTableName;
         private final List<ForeignKey> fkList = new ArrayList<>();

--- a/src/main/java/org/sqlite/jdbc3/JDBC3ResultSet.java
+++ b/src/main/java/org/sqlite/jdbc3/JDBC3ResultSet.java
@@ -25,6 +25,8 @@ import org.sqlite.core.CoreStatement;
 import org.sqlite.core.DB;
 import org.sqlite.date.FastDateFormat;
 
+import static org.sqlite.util.PatternConstants.*;
+
 public abstract class JDBC3ResultSet extends CoreResultSet {
     // ResultSet Functions //////////////////////////////////////////
 
@@ -551,17 +553,6 @@ public abstract class JDBC3ResultSet extends CoreResultSet {
 
     // ResultSetMetaData Functions //////////////////////////////////
 
-    /** Pattern used to extract the column type name from table column definition. */
-    protected static final Pattern COLUMN_TYPENAME = Pattern.compile("([^\\(]*)");
-
-    /** Pattern used to extract the column type name from a cast(col as type) */
-    protected static final Pattern COLUMN_TYPECAST =
-            Pattern.compile("cast\\(.*?\\s+as\\s+(.*?)\\s*\\)");
-
-    /**
-     * Pattern used to extract the precision and scale from column meta returned by the JDBC driver.
-     */
-    protected static final Pattern COLUMN_PRECISION = Pattern.compile(".*?\\((.*?)\\)");
 
     // we do not need to check the RS is open, only that colsMeta
     // is not null, done with checkCol(int).

--- a/src/main/java/org/sqlite/util/PatternConstants.java
+++ b/src/main/java/org/sqlite/util/PatternConstants.java
@@ -1,0 +1,66 @@
+package org.sqlite.util;
+
+import java.util.regex.Pattern;
+
+public final class PatternConstants {
+    /**
+     * Pattern to match integer or boolean types.
+     */
+    public static final Pattern TYPE_INTEGER = Pattern.compile(".*(INT|BOOL).*");
+
+    /**
+     * Pattern to match varchar, text, or blob types.
+     */
+    public static final Pattern TYPE_VARCHAR = Pattern.compile(".*(CHAR|CLOB|TEXT|BLOB).*");
+
+    /**
+     * Pattern to match float, double, decimal, or numeric types.
+     */
+    public static final Pattern TYPE_FLOAT = Pattern.compile(".*(REAL|FLOA|DOUB|DEC|NUM).*");
+
+    /** 
+     * Pattern used to extract column order for an unnamed primary key. 
+     */
+    public static final Pattern PK_UNNAMED_PATTERN = Pattern.compile(".*PRIMARY\\s+KEY\\s*\\((.*?)\\).*", Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
+
+    /**
+     *  Pattern used to extract a named primary key. 
+     **/
+    public static final Pattern PK_NAMED_PATTERN = Pattern.compile(".*CONSTRAINT\\s*(.*?)\\s*PRIMARY\\s+KEY\\s*\\((.*?)\\).*", Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
+
+    /**
+     *  Pattern used to extract a named primary key. 
+     */
+    public static final Pattern FK_NAMED_PATTERN = Pattern.compile("CONSTRAINT\\s*\"?([A-Za-z_][A-Za-z\\d_]*)?\"?\\s*FOREIGN\\s+KEY\\s*\\((.*?)\\)", Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
+
+    /**
+     *  A <code>Pattern</code> to parse the user supplied SimpleDateFormat pattern 
+     */
+    public static final Pattern FORMAT_PATTERN = Pattern.compile("D+|E+|F+|G+|H+|K+|M+|S+|W+|X+|Z+|a+|d+|h+|k+|m+|s+|w+|y+|z+|''|'[^']++(''[^']*+)*+'|[^'A-Za-z]++");
+
+    /**
+     *  Pattern used to extract the column type name from table column definition. 
+     */
+    public static final Pattern COLUMN_TYPENAME = Pattern.compile("([^\\(]*)");
+
+    /**
+     *  Pattern used to extract the column type name from a cast(col as type) 
+     */
+    public static final Pattern COLUMN_TYPECAST = Pattern.compile("cast\\(.*?\\s+as\\s+(.*?)\\s*\\)");
+
+    /**
+     * Pattern used to extract the precision and scale from column meta returned by the JDBC driver.
+     */
+    public static final Pattern COLUMN_PRECISION = Pattern.compile(".*?\\((.*?)\\)");
+
+    /**
+     * Pattern used for matching insert statements of the general format starting with INSERT or REPLACE.
+     * CTEs used prior to the insert or replace keyword are also be permitted.
+    */
+    public static final Pattern INSERT_PATTERN = Pattern.compile( "^\\s*(?:with\\s+.+\\(.+?\\))*\\s*(?:insert|replace)\\s*", Pattern.DOTALL | Pattern.CASE_INSENSITIVE);
+
+    public static final Pattern BACKUP_CMD = Pattern.compile("backup(\\s+(\"[^\"]*\"|'[^\']*\'|\\S+))?\\s+to\\s+(\"[^\"]*\"|'[^\']*\'|\\S+)",Pattern.CASE_INSENSITIVE);
+
+    public static final Pattern RESTORE_CMD = Pattern.compile("restore(\\s+(\"[^\"]*\"|'[^\']*\'|\\S+))?\\s+from\\s+(\"[^\"]*\"|'[^\']*\'|\\S+)", Pattern.CASE_INSENSITIVE);
+
+}


### PR DESCRIPTION
- Moved all regex patterns (`TYPE_INTEGER`, `TYPE_VARCHAR`, `PK_UNNAMED_PATTERN`, etc.) into a single `PatternConstants` class.
- Added patterns for column types, primary/foreign keys, date formats, and SQL commands.
- Updated references to use the centralized constants.

This change improves code organization, reduces duplication, and makes the patterns easier to maintain.