### PR TITLE
refactor: Extract parsing strategies from FastDateParser

### DIFF
--- a/src/main/java/org/sqlite/date/CaseInsensitiveTextStrategy.java
+++ b/src/main/java/org/sqlite/date/CaseInsensitiveTextStrategy.java
@@ -1,0 +1,62 @@
+package org.sqlite.date;
+
+import java.util.Calendar;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+import static org.sqlite.date.FastDateParser.escapeRegex;
+import static org.sqlite.date.FastDateParser.getDisplayNames;
+
+/** A strategy that handles a text field in the parsing pattern */
+public class CaseInsensitiveTextStrategy extends DateParsingStrategy {
+    private final int field;
+    private final Locale locale;
+    private final Map<String, Integer> lKeyValues;
+
+    /**
+     * Construct a Strategy that parses a Text field
+     *
+     * @param field The Calendar field
+     * @param definingCalendar The Calendar to use
+     * @param locale The Locale to use
+     */
+    CaseInsensitiveTextStrategy(
+            final int field, final Calendar definingCalendar, final Locale locale) {
+        this.field = field;
+        this.locale = locale;
+        final Map<String, Integer> keyValues = getDisplayNames(field, definingCalendar, locale);
+        this.lKeyValues = new HashMap<String, Integer>();
+
+        for (final Map.Entry<String, Integer> entry : keyValues.entrySet()) {
+            lKeyValues.put(entry.getKey().toLowerCase(locale), entry.getValue());
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    boolean addRegex(final FastDateParser parser, final StringBuilder regex) {
+        regex.append("((?iu)");
+        for (final String textKeyValue : lKeyValues.keySet()) {
+            escapeRegex(regex, textKeyValue, false).append('|');
+        }
+        regex.setCharAt(regex.length() - 1, ')');
+        return true;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    void setCalendar(final FastDateParser parser, final Calendar cal, final String value) {
+        final Integer iVal = lKeyValues.get(value.toLowerCase(locale));
+        if (iVal == null) {
+            final StringBuilder sb = new StringBuilder(value);
+            sb.append(" not in (");
+            for (final String textKeyValue : lKeyValues.keySet()) {
+                sb.append(textKeyValue).append(' ');
+            }
+            sb.setCharAt(sb.length() - 1, ')');
+            throw new IllegalArgumentException(sb.toString());
+        }
+        cal.set(field, iVal.intValue());
+    }
+}

--- a/src/main/java/org/sqlite/date/CopyQuotedDateParsingStrategy.java
+++ b/src/main/java/org/sqlite/date/CopyQuotedDateParsingStrategy.java
@@ -1,0 +1,34 @@
+package org.sqlite.date;
+
+import static org.sqlite.date.FastDateParser.escapeRegex;
+
+/** A strategy that copies the static or quoted field in the parsing pattern */
+public class CopyQuotedDateParsingStrategy extends DateParsingStrategy {
+    private final String formatField;
+
+    /**
+     * Construct a Strategy that ensures the formatField has literal text
+     *
+     * @param formatField The literal text to match
+     */
+    CopyQuotedDateParsingStrategy(final String formatField) {
+        this.formatField = formatField;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    boolean isNumber() {
+        char c = formatField.charAt(0);
+        if (c == '\'') {
+            c = formatField.charAt(1);
+        }
+        return Character.isDigit(c);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    boolean addRegex(final FastDateParser parser, final StringBuilder regex) {
+        escapeRegex(regex, formatField, true);
+        return false;
+    }
+}

--- a/src/main/java/org/sqlite/date/DateParsingStrategy.java
+++ b/src/main/java/org/sqlite/date/DateParsingStrategy.java
@@ -1,0 +1,38 @@
+package org.sqlite.date;
+
+import java.util.Calendar;
+
+/** A strategy to parse a single field from the parsing pattern */
+public abstract class DateParsingStrategy {
+
+    /**
+     * Is this field a number? The default implementation returns false.
+     *
+     * @return true, if field is a number
+     */
+    boolean isNumber() {
+        return false;
+    }
+
+    /**
+     * Set the Calendar with the parsed field.
+     *
+     * <p>The default implementation does nothing.
+     *
+     * @param parser The parser calling this strategy
+     * @param cal The <code>Calendar</code> to set
+     * @param value The parsed field to translate and set in cal
+     */
+    void setCalendar(final FastDateParser parser, final Calendar cal, final String value) {}
+
+    /**
+     * Generate a <code>Pattern</code> regular expression to the <code>StringBuilder</code>
+     * which will accept this field
+     *
+     * @param parser The parser calling this strategy
+     * @param regex The <code>StringBuilder</code> to append to
+     * @return true, if this field will set the calendar; false, if this field is a constant
+     *     value
+     */
+    abstract boolean addRegex(FastDateParser parser, StringBuilder regex);
+}

--- a/src/main/java/org/sqlite/date/ISO8601TimeZoneDateParsingStrategy.java
+++ b/src/main/java/org/sqlite/date/ISO8601TimeZoneDateParsingStrategy.java
@@ -1,0 +1,62 @@
+package org.sqlite.date;
+
+import java.util.Calendar;
+import java.util.TimeZone;
+
+public class ISO8601TimeZoneDateParsingStrategy extends DateParsingStrategy {
+    // Z, +hh, -hh, +hhmm, -hhmm, +hh:mm or -hh:mm
+    private final String pattern;
+
+    /**
+     * Construct a Strategy that parses a TimeZone
+     *
+     * @param pattern The Pattern
+     */
+    ISO8601TimeZoneDateParsingStrategy(String pattern) {
+        this.pattern = pattern;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    boolean addRegex(FastDateParser parser, StringBuilder regex) {
+        regex.append(pattern);
+        return true;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    void setCalendar(FastDateParser parser, Calendar cal, String value) {
+        if (value.equals("Z")) {
+            cal.setTimeZone(TimeZone.getTimeZone("UTC"));
+        } else {
+            cal.setTimeZone(TimeZone.getTimeZone("GMT" + value));
+        }
+    }
+
+    private static final DateParsingStrategy ISO_86011_DATE_PARSING_STRATEGY =
+            new ISO8601TimeZoneDateParsingStrategy("(Z|(?:[+-]\\d{2}))");
+    private static final DateParsingStrategy ISO_86012_DATE_PARSING_STRATEGY =
+            new ISO8601TimeZoneDateParsingStrategy("(Z|(?:[+-]\\d{2}\\d{2}))");
+    private static final DateParsingStrategy ISO_86013_DATE_PARSING_STRATEGY =
+            new ISO8601TimeZoneDateParsingStrategy("(Z|(?:[+-]\\d{2}(?::)\\d{2}))");
+
+    /**
+     * Factory method for ISO8601TimeZoneStrategies.
+     *
+     * @param tokenLen a token indicating the length of the TimeZone String to be formatted.
+     * @return a ISO8601TimeZoneStrategy that can format TimeZone String of length {@code
+     *     tokenLen}. If no such strategy exists, an IllegalArgumentException will be thrown.
+     */
+    static DateParsingStrategy getStrategy(int tokenLen) {
+        switch (tokenLen) {
+            case 1:
+                return ISO_86011_DATE_PARSING_STRATEGY;
+            case 2:
+                return ISO_86012_DATE_PARSING_STRATEGY;
+            case 3:
+                return ISO_86013_DATE_PARSING_STRATEGY;
+            default:
+                throw new IllegalArgumentException("invalid number of X");
+        }
+    }
+}

--- a/src/main/java/org/sqlite/date/NumberDateParsingStrategy.java
+++ b/src/main/java/org/sqlite/date/NumberDateParsingStrategy.java
@@ -1,0 +1,52 @@
+package org.sqlite.date;
+
+import java.util.Calendar;
+
+/** A strategy that handles a number field in the parsing pattern */
+public class NumberDateParsingStrategy extends DateParsingStrategy {
+    private final int field;
+
+    /**
+     * Construct a Strategy that parses a Number field
+     *
+     * @param field The Calendar field
+     */
+    NumberDateParsingStrategy(final int field) {
+        this.field = field;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    boolean isNumber() {
+        return true;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    boolean addRegex(final FastDateParser parser, final StringBuilder regex) {
+        // See LANG-954: We use {Nd} rather than {IsNd} because Android does not support the Is
+        // prefix
+        if (parser.isNextNumber()) {
+            regex.append("(\\p{Nd}{").append(parser.getFieldWidth()).append("}+)");
+        } else {
+            regex.append("(\\p{Nd}++)");
+        }
+        return true;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    void setCalendar(final FastDateParser parser, final Calendar cal, final String value) {
+        cal.set(field, modify(Integer.parseInt(value)));
+    }
+
+    /**
+     * Make any modifications to parsed integer
+     *
+     * @param iValue The parsed integer
+     * @return The modified value
+     */
+    int modify(final int iValue) {
+        return iValue;
+    }
+}

--- a/src/main/java/org/sqlite/date/TimeZoneDateParsingStrategy.java
+++ b/src/main/java/org/sqlite/date/TimeZoneDateParsingStrategy.java
@@ -1,0 +1,87 @@
+package org.sqlite.date;
+
+import java.text.DateFormatSymbols;
+import java.util.*;
+
+import static org.sqlite.date.FastDateParser.escapeRegex;
+
+/** A strategy that handles a timezone field in the parsing pattern */
+public class TimeZoneDateParsingStrategy extends DateParsingStrategy {
+
+    private final String validTimeZoneChars;
+    private final SortedMap<String, TimeZone> tzNames =
+            new TreeMap<String, TimeZone>(String.CASE_INSENSITIVE_ORDER);
+
+    /** Index of zone id */
+    private static final int ID = 0;
+    /** Index of the long name of zone in standard time */
+    private static final int LONG_STD = 1;
+    /** Index of the short name of zone in standard time */
+    private static final int SHORT_STD = 2;
+    /** Index of the long name of zone in daylight saving time */
+    private static final int LONG_DST = 3;
+    /** Index of the short name of zone in daylight saving time */
+    private static final int SHORT_DST = 4;
+
+    /**
+     * Construct a Strategy that parses a TimeZone
+     *
+     * @param locale The Locale
+     */
+    TimeZoneDateParsingStrategy(final Locale locale) {
+        final String[][] zones = DateFormatSymbols.getInstance(locale).getZoneStrings();
+        for (final String[] zone : zones) {
+            if (zone[ID].startsWith("GMT")) {
+                continue;
+            }
+            final TimeZone tz = TimeZone.getTimeZone(zone[ID]);
+            if (!tzNames.containsKey(zone[LONG_STD])) {
+                tzNames.put(zone[LONG_STD], tz);
+            }
+            if (!tzNames.containsKey(zone[SHORT_STD])) {
+                tzNames.put(zone[SHORT_STD], tz);
+            }
+            if (tz.useDaylightTime()) {
+                if (!tzNames.containsKey(zone[LONG_DST])) {
+                    tzNames.put(zone[LONG_DST], tz);
+                }
+                if (!tzNames.containsKey(zone[SHORT_DST])) {
+                    tzNames.put(zone[SHORT_DST], tz);
+                }
+            }
+        }
+
+        final StringBuilder sb = new StringBuilder();
+        sb.append("(GMT[+-]\\d{1,2}:\\d{2}").append('|');
+        sb.append("[+-]\\d{4}").append('|');
+        for (final String id : tzNames.keySet()) {
+            escapeRegex(sb, id, false).append('|');
+        }
+        sb.setCharAt(sb.length() - 1, ')');
+        validTimeZoneChars = sb.toString();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    boolean addRegex(final FastDateParser parser, final StringBuilder regex) {
+        regex.append(validTimeZoneChars);
+        return true;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    void setCalendar(final FastDateParser parser, final Calendar cal, final String value) {
+        TimeZone tz;
+        if (value.charAt(0) == '+' || value.charAt(0) == '-') {
+            tz = TimeZone.getTimeZone("GMT" + value);
+        } else if (value.startsWith("GMT")) {
+            tz = TimeZone.getTimeZone(value);
+        } else {
+            tz = tzNames.get(value);
+            if (tz == null) {
+                throw new IllegalArgumentException(value + " is not a supported timezone name");
+            }
+        }
+        cal.setTimeZone(tz);
+    }
+}


### PR DESCRIPTION
- Extracted `CaseInsensitiveTextStrategy` for case-insensitive text parsing.
- Extracted `CopyQuotedDateParsingStrategy` for quoted/static field parsing.
- Extracted `DateParsingStrategy` as the base class for all strategies.
- Extracted `ISO8601TimeZoneDateParsingStrategy` for ISO 8601 time zone parsing.
- Extracted `NumberDateParsingStrategy` for numeric field parsing.
- Extracted `TimeZoneDateParsingStrategy` for general time zone parsing.

This change improves modularity, readability, and maintainability by adhering to the Single Responsibility Principle.