### PR TITLE
remove an undocumented side-effect from SQLiteConnection::open

### DIFF
--- a/src/main/java/org/sqlite/SQLiteConnection.java
+++ b/src/main/java/org/sqlite/SQLiteConnection.java
@@ -251,26 +251,7 @@ public abstract class SQLiteConnection implements Connection {
                     throw new SQLException(String.format("failed to load %s: %s", resourceName, e));
                 }
             } else {
-                File file = new File(fileName).getAbsoluteFile();
-                File parent = file.getParentFile();
-                if (parent != null && !parent.exists()) {
-                    for (File up = parent; up != null && !up.exists(); ) {
-                        parent = up;
-                        up = up.getParentFile();
-                    }
-                    throw new SQLException(
-                            "path to '" + fileName + "': '" + parent + "' does not exist");
-                }
-
-                // check write access if file does not exist
-                try {
-                    // The extra check to exists() is necessary as createNewFile()
-                    // does not follow the JavaDoc when used on read-only shares.
-                    if (!file.exists() && file.createNewFile()) file.delete();
-                } catch (Exception e) {
-                    throw new SQLException("opening db: '" + fileName + "': " + e.getMessage());
-                }
-                fileName = file.getAbsolutePath();
+                fileName = new File(fileName).getAbsolutePath();
             }
         }
 

--- a/src/test/java/org/sqlite/ConnectionTest.java
+++ b/src/test/java/org/sqlite/ConnectionTest.java
@@ -17,13 +17,13 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 import org.sqlite.SQLiteConfig.JournalMode;
 import org.sqlite.SQLiteConfig.Pragma;
 import org.sqlite.SQLiteConfig.SynchronousMode;
-import org.sqlite.util.OSInfo;
 
 /**
  * These tests check whether access to files is working correctly and some Connection.close() cases.
@@ -433,12 +433,9 @@ public class ConnectionTest {
     }
 
     @SuppressWarnings("resource")
+    @DisabledOnOs(OS.WINDOWS) // File.setReadOnly doesn't seem to work here
     @Test
     public void openNonExistingFileInReadOnlyDirectory(@TempDir Path tmpDir) {
-        // skip test on windows as there marking a folder as readonly doesn't seem to work with pure
-        // java means
-        Assumptions.assumeFalse(OSInfo.getOSName().equals("Windows"));
-
         assertThat(tmpDir.toFile().setReadOnly()).isTrue();
         assertThat(Files.exists(tmpDir)).isTrue();
         Path nonExisting = tmpDir.resolve("non_existing.db").toAbsolutePath();

--- a/src/test/java/org/sqlite/ConnectionTest.java
+++ b/src/test/java/org/sqlite/ConnectionTest.java
@@ -6,6 +6,10 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.AccessDeniedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.sql.*;
 import java.util.ArrayList;
 import java.util.Properties;
@@ -13,11 +17,13 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.sqlite.SQLiteConfig.JournalMode;
 import org.sqlite.SQLiteConfig.Pragma;
 import org.sqlite.SQLiteConfig.SynchronousMode;
+import org.sqlite.util.OSInfo;
 
 /**
  * These tests check whether access to files is working correctly and some Connection.close() cases.
@@ -408,5 +414,47 @@ public class ConnectionTest {
 
         stat.close();
         conn.close();
+    }
+
+    @SuppressWarnings("resource")
+    @Test
+    public void openNonExistingFileNoCreate() {
+        Path nonExisting = Paths.get("non_existing.db").toAbsolutePath();
+        assertThat(Files.exists(nonExisting)).isFalse();
+        SQLiteConfig cfg = new SQLiteConfig();
+        cfg.resetOpenMode(SQLiteOpenMode.CREATE);
+        assertThatExceptionOfType(SQLiteException.class)
+                .isThrownBy(() -> cfg.createConnection("jdbc:sqlite:" + nonExisting))
+                .satisfies(
+                        e ->
+                                assertThat(e.getResultCode())
+                                        .isEqualTo(SQLiteErrorCode.SQLITE_CANTOPEN));
+        assertThat(Files.exists(nonExisting)).isFalse();
+    }
+
+    @SuppressWarnings("resource")
+    @Test
+    public void openNonExistingFileInReadOnlyDirectory(@TempDir Path tmpDir) {
+        // skip test on windows as there marking a folder as readonly doesn't seem to work with pure
+        // java means
+        Assumptions.assumeFalse(OSInfo.getOSName().equals("Windows"));
+
+        assertThat(tmpDir.toFile().setReadOnly()).isTrue();
+        assertThat(Files.exists(tmpDir)).isTrue();
+        Path nonExisting = tmpDir.resolve("non_existing.db").toAbsolutePath();
+        assertThatThrownBy(() -> Files.createFile(nonExisting))
+                .isInstanceOf(AccessDeniedException.class);
+        assertThat(Files.exists(nonExisting)).isFalse();
+        SQLiteConfig cfg = new SQLiteConfig();
+        assertThatExceptionOfType(SQLiteException.class)
+                .isThrownBy(() -> cfg.createConnection("jdbc:sqlite:" + nonExisting))
+                .satisfies(
+                        e ->
+                                // It would be nice, if the native error code were more specific on
+                                // why the file can't be
+                                // opened, but this is what we get:
+                                assertThat(e.getResultCode())
+                                        .isEqualTo(SQLiteErrorCode.SQLITE_CANTOPEN));
+        assertThat(Files.exists(nonExisting)).isFalse();
     }
 }

--- a/src/test/java/org/sqlite/ConnectionTest.java
+++ b/src/test/java/org/sqlite/ConnectionTest.java
@@ -416,7 +416,6 @@ public class ConnectionTest {
         conn.close();
     }
 
-    @SuppressWarnings("resource")
     @Test
     public void openNonExistingFileNoCreate() {
         Path nonExisting = Paths.get("non_existing.db").toAbsolutePath();
@@ -424,7 +423,11 @@ public class ConnectionTest {
         SQLiteConfig cfg = new SQLiteConfig();
         cfg.resetOpenMode(SQLiteOpenMode.CREATE);
         assertThatExceptionOfType(SQLiteException.class)
-                .isThrownBy(() -> cfg.createConnection("jdbc:sqlite:" + nonExisting))
+                .isThrownBy(
+                        () -> {
+                            @SuppressWarnings({"resource", "unused"})
+                            Connection _c = cfg.createConnection("jdbc:sqlite:" + nonExisting);
+                        })
                 .satisfies(
                         e ->
                                 assertThat(e.getResultCode())
@@ -432,7 +435,6 @@ public class ConnectionTest {
         assertThat(Files.exists(nonExisting)).isFalse();
     }
 
-    @SuppressWarnings("resource")
     @DisabledOnOs(OS.WINDOWS) // File.setReadOnly doesn't seem to work here
     @Test
     public void openNonExistingFileInReadOnlyDirectory(@TempDir Path tmpDir) {
@@ -444,7 +446,11 @@ public class ConnectionTest {
         assertThat(Files.exists(nonExisting)).isFalse();
         SQLiteConfig cfg = new SQLiteConfig();
         assertThatExceptionOfType(SQLiteException.class)
-                .isThrownBy(() -> cfg.createConnection("jdbc:sqlite:" + nonExisting))
+                .isThrownBy(
+                        () -> {
+                            @SuppressWarnings({"resource", "unused"})
+                            Connection _c = cfg.createConnection("jdbc:sqlite:" + nonExisting);
+                        })
                 .satisfies(
                         e ->
                                 // It would be nice, if the native error code were more specific on


### PR DESCRIPTION
The side-effect consisted in temporarily creating a non-existing db-file to test for write-permission, see #1260
Also add some test to better document the expected behavior.