### PR TITLE
fix#1279

### DIFF
--- a/src/main/java/org/sqlite/jdbc3/JDBC3ResultSet.java
+++ b/src/main/java/org/sqlite/jdbc3/JDBC3ResultSet.java
@@ -573,7 +573,7 @@ public abstract class JDBC3ResultSet extends CoreResultSet {
 
     /** @see java.sql.ResultSetMetaData#getCatalogName(int) */
     public String getCatalogName(int col) throws SQLException {
-        return safeGetColumnTableName(col);
+        return "";
     }
 
     /** @see java.sql.ResultSetMetaData#getColumnClassName(int) */

--- a/src/test/java/org/sqlite/RSMetaDataTest.java
+++ b/src/test/java/org/sqlite/RSMetaDataTest.java
@@ -43,7 +43,12 @@ public class RSMetaDataTest {
 
     @Test
     public void catalogName() throws SQLException {
-        assertThat(meta.getCatalogName(1)).isEqualTo("People");
+        assertThat(meta.getCatalogName(1)).isEqualTo("");
+    }
+
+    @Test
+    public void schemaName() throws SQLException {
+        assertThat(meta.getSchemaName(1)).isEqualTo("");
     }
 
     @Test
@@ -196,8 +201,8 @@ public class RSMetaDataTest {
     }
 
     @Test
-    public void badCatalogIndex() {
-        assertThatExceptionOfType(SQLException.class).isThrownBy(() -> meta.getCatalogName(4));
+    public void badTableIndex() {
+        assertThatExceptionOfType(SQLException.class).isThrownBy(() -> meta.getTableName(5));
     }
 
     @Test


### PR DESCRIPTION
[Fix#1279](https://github.com/xerial/sqlite-jdbc/issues/1279)

Fix the use of [ResultSetMetaData.getCatalogName(int column)](https://docs.oracle.com/javase/8/docs/api/java/sql/ResultSetMetaData.html#getCatalogName-int-) method