### PR TITLE
Update JDBC3DatabaseMetaData to enable supported features

### DIFF
--- a/src/main/java/org/sqlite/jdbc3/JDBC3DatabaseMetaData.java
+++ b/src/main/java/org/sqlite/jdbc3/JDBC3DatabaseMetaData.java
@@ -438,12 +438,12 @@ public abstract class JDBC3DatabaseMetaData extends CoreDatabaseMetaData {
 
     /** @see java.sql.DatabaseMetaData#supportsAlterTableWithAddColumn() */
     public boolean supportsAlterTableWithAddColumn() {
-        return false;
+        return true;
     }
 
     /** @see java.sql.DatabaseMetaData#supportsAlterTableWithDropColumn() */
     public boolean supportsAlterTableWithDropColumn() {
-        return false;
+        return true;
     }
 
     /** @see java.sql.DatabaseMetaData#supportsANSI92EntryLevelSQL() */


### PR DESCRIPTION
Enable `supportsAlterTableWithDropColumn` and `supportsAlterTableWithAddColumn` that should be already supported by the driver.

These are both supported from 3.35.0, so the metadata should return `true`, so tools that depend on it it can work correctly. [(discussion](https://github.com/xerial/sqlite-jdbc/discussions/1285))

*NOTE*: I did not check if other properties from the metadata are wrong.

Let me know if you have any comments.
Thanks!