### PR TITLE
Support JDBC4 CLOB and BLOB in PreparedStatement parameters

### DIFF
--- a/src/main/java/org/sqlite/jdbc3/JDBC3PreparedStatement.java
+++ b/src/main/java/org/sqlite/jdbc3/JDBC3PreparedStatement.java
@@ -390,13 +390,14 @@ public abstract class JDBC3PreparedStatement extends CorePreparedStatement {
     /** @see java.sql.PreparedStatement#setCharacterStream(int, java.io.Reader, int) */
     public void setCharacterStream(int pos, Reader reader, int length) throws SQLException {
         try {
-            // copy chars from reader to StringBuffer
-            StringBuffer sb = new StringBuffer();
+            // copy chars from reader to StringBuilder
+            StringBuilder sb = new StringBuilder();
             char[] cbuf = new char[8192];
             int cnt;
 
-            while ((cnt = reader.read(cbuf)) > 0) {
+            while ((cnt = reader.read(cbuf, 0, Math.min(length, cbuf.length))) > 0) {
                 sb.append(cbuf, 0, cnt);
+                length -= cnt;
             }
 
             // set as string

--- a/src/test/java/org/sqlite/PrepStmtTest.java
+++ b/src/test/java/org/sqlite/PrepStmtTest.java
@@ -7,6 +7,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.data.Offset.offset;
 
 import java.io.ByteArrayInputStream;
+import java.io.StringReader;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
@@ -173,6 +174,32 @@ public class PrepStmtTest {
         assertThat(prep.getUpdateCount()).isEqualTo(-1);
         assertThat(rs.next()).isTrue();
         assertThat(name).isEqualTo(rs.getString(1));
+        assertThat(rs.next()).isFalse();
+        rs.close();
+    }
+
+    @Test
+    public void clobRS() throws SQLException {
+        String name = "Gandhi";
+        PreparedStatement prep = conn.prepareStatement("select ?;");
+        prep.setClob(1, new StringReader(name));
+        ResultSet rs = prep.executeQuery();
+        assertThat(prep.getUpdateCount()).isEqualTo(-1);
+        assertThat(rs.next()).isTrue();
+        assertThat(rs.getString(1)).isEqualTo(name);
+        assertThat(rs.next()).isFalse();
+        rs.close();
+    }
+
+    @Test
+    public void blobRS() throws SQLException {
+        String name = "Gandhi";
+        PreparedStatement prep = conn.prepareStatement("select ?;");
+        prep.setBlob(1, new ByteArrayInputStream(name.getBytes()));
+        ResultSet rs = prep.executeQuery();
+        assertThat(prep.getUpdateCount()).isEqualTo(-1);
+        assertThat(rs.next()).isTrue();
+        assertThat(rs.getBytes(1)).isEqualTo(name.getBytes());
         assertThat(rs.next()).isFalse();
         rs.close();
     }


### PR DESCRIPTION
There are TODO markers in the JDBC4 Prepared Statement implementation relating to BLOB and CLOB data. These can easily be implemented by delegating to the existing JDBC implementations. This may not be optimised, but it will allow the use of CLOB and BLOB, which is a significant improvement.