### PR TITLE
build(deps): org.graalvm.buildtools:native-maven-plugin from 0.10.6 to 0.11.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        java: [ '17', '21', '24' ]
+        java: [ '17', '21', '25' ]
         profiles: ['native', 'native,native-exported']
     runs-on: ${{ matrix.os }}
     steps:

--- a/pom.xml
+++ b/pom.xml
@@ -331,7 +331,7 @@
                     <plugin>
                         <groupId>org.graalvm.buildtools</groupId>
                         <artifactId>native-maven-plugin</artifactId>
-                        <version>0.10.6</version>
+                        <version>0.11.2</version>
                         <extensions>true</extensions>
                         <executions>
                             <execution>
@@ -346,6 +346,16 @@
                             <fallback>false</fallback>
                             <verbose>true</verbose>
                             <buildArgs>
+                                <!--
+                                Only required for GraalVM for JDK 17.
+                                The option is deprecated in later versions and could cause failures on later GraalVM versions.
+                                -->
+                                <arg>-H:+AllowDeprecatedBuilderClassesOnImageClasspath</arg>
+
+                                <!--
+                                The initialization flags below seem only necessary for GraalVM for JDK 17 and 21.
+                                If CI checks for either of these GraalVM versions are dropped, this should be cleaned up.
+                                -->
                                 <!-- required to allow junit-pioneer to compile with strict image heap enabled -->
                                 <arg>--initialize-at-build-time=org.junitpioneer.jupiter.issue.IssueExtensionExecutionListener</arg>
                                 <!--
@@ -357,6 +367,8 @@
                                 <arg>--initialize-at-build-time=org.junit.jupiter.api.parallel.ResourceLock</arg>
                                 <arg>--initialize-at-build-time=org.junit.jupiter.api.parallel.ResourceLockTarget</arg>
                                 <arg>--initialize-at-build-time=org.junit.jupiter.api.parallel.ResourceAccessMode</arg>
+                                <arg>--initialize-at-build-time=org.junit.jupiter.engine.descriptor.ExclusiveResourceCollector$1</arg>
+                                <arg>--initialize-at-build-time=org.junit.platform.commons.support.scanning.DefaultClasspathScanner</arg>
                             </buildArgs>
                         </configuration>
                     </plugin>


### PR DESCRIPTION
- update required native-image arguments
- bump ci to GraalVM 25 to run against LTS


Changes seems to mostly be related to this I think: https://github.com/graalvm/native-build-tools/pull/693
I've added some comments inline on the PR to clarify.
Interestingly, everything seemed to run fine without any changes on JDK 25 (on Windows at least)