### PR TITLE
build: conditionally bootstrap SLF4J API JAR

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -17,8 +17,10 @@ JAVA_CLASSPATH?=$(TARGET)/classpath/slf4j-api.jar
 ## building OSInfo.java
 ifeq ("$(wildcard $(OSINFO_PROG))","")
 $(info Building OSInfo tool)
-$(shell mkdir -p $(TARGET)/classpath)
+$(shell mkdir -p $(dir $(JAVA_CLASSPATH)))
+ifeq ("$(wildcard $(JAVA_CLASSPATH))","")
 $(shell curl -L -f -o$(JAVA_CLASSPATH) https://search.maven.org/remotecontent?filepath=org/slf4j/slf4j-api/1.7.36/slf4j-api-1.7.36.jar)
+endif
 $(shell $(JAVAC) -cp $(JAVA_CLASSPATH) -sourcepath $(SRC) -d lib src/main/java/org/sqlite/util/OSInfo.java)
 endif
 


### PR DESCRIPTION
Create the classpath directory derived from JAVA_CLASSPATH regardless of the location and only download SFL4J API JAR if it is not present.