### PR TITLE
fix(jdbc): escape table name in getColumns metadata query

### DIFF
--- a/src/main/java/org/sqlite/jdbc3/JDBC3DatabaseMetaData.java
+++ b/src/main/java/org/sqlite/jdbc3/JDBC3DatabaseMetaData.java
@@ -1095,7 +1095,7 @@ public abstract class JDBC3DatabaseMetaData extends CoreDatabaseMetaData {
                                 .append(iDecimalDigits)
                                 .append(" as colDecimalDigits, ")
                                 .append("'")
-                                .append(tableName)
+                                .append(escape(tableName))
                                 .append("' as tblname, ")
                                 .append("'")
                                 .append(escape(colName))

--- a/src/test/java/org/sqlite/DBMetaDataTest.java
+++ b/src/test/java/org/sqlite/DBMetaDataTest.java
@@ -478,6 +478,20 @@ public class DBMetaDataTest {
     }
 
     @Test
+    public void getColumnsTableNameWithQuote() throws SQLException {
+        stat.executeUpdate("create table \"o'brien\" (id integer, name text)");
+
+        ResultSet rs = meta.getColumns(null, null, "o'brien", "%");
+        assertThat(rs.next()).isTrue();
+        assertThat(rs.getString("TABLE_NAME")).isEqualTo("o'brien");
+        assertThat(rs.getString("COLUMN_NAME")).isEqualTo("id");
+        assertThat(rs.next()).isTrue();
+        assertThat(rs.getString("TABLE_NAME")).isEqualTo("o'brien");
+        assertThat(rs.getString("COLUMN_NAME")).isEqualTo("name");
+        assertThat(rs.next()).isFalse();
+    }
+
+    @Test
     public void getColumnsPrecisionScale() throws SQLException {
         stat.executeUpdate("create table gh_1215 (n numeric ( 10 , 5 ), d decimal ( 10 ))");
 


### PR DESCRIPTION
getColumns reads each matching table name back from sqlite_schema (through getTables) and builds an internal query from it, but the table name is concatenated straight into a single-quoted literal for the tblname column while every other identifier in the same loop already goes through escape(). A table whose name contains a single quote is a perfectly valid SQLite identifier, so the generated query ends up malformed and the embedded text is treated as SQL, which means a crafted table name can break or inject into the metadata query. I have wrapped the value in escape() so the quote is doubled like the surrounding columns. Added a small regression test under DBMetaDataTest that creates a table with a quote in its name and reads its columns back.