### PR TITLE
fix(jdbc): escape table type values in getTables metadata query

### DIFF
--- a/src/main/java/org/sqlite/jdbc3/JDBC3DatabaseMetaData.java
+++ b/src/main/java/org/sqlite/jdbc3/JDBC3DatabaseMetaData.java
@@ -1740,7 +1740,7 @@ public abstract class JDBC3DatabaseMetaData extends CoreDatabaseMetaData {
             sql.append(" AND TABLE_TYPE IN (");
             sql.append(
                     Arrays.stream(types)
-                            .map((t) -> "'" + t.toUpperCase() + "'")
+                            .map((t) -> "'" + escape(t.toUpperCase()) + "'")
                             .collect(Collectors.joining(",")));
             sql.append(")");
         }

--- a/src/test/java/org/sqlite/DBMetaDataTest.java
+++ b/src/test/java/org/sqlite/DBMetaDataTest.java
@@ -478,6 +478,15 @@ public class DBMetaDataTest {
     }
 
     @Test
+    public void getTablesTypeWithQuote() throws SQLException {
+        // a type containing a single quote must be treated as a literal, not break out of the
+        // TABLE_TYPE IN (...) list; 'X' matches nothing so the result must be empty
+        try (ResultSet rs = meta.getTables(null, null, null, new String[] {"X') OR ('1'='1"})) {
+            assertThat(rs.next()).isFalse();
+        }
+    }
+
+    @Test
     public void getColumnsTableNameWithQuote() throws SQLException {
         stat.executeUpdate("create table \"o'brien\" (id integer, name text)");
 


### PR DESCRIPTION
the types argument passed to getTables is interpolated straight into the TABLE_TYPE IN (...) list without escape(), unlike the other identifiers used in these metadata queries, so a type value containing a single quote breaks the generated SQL and can change what the query returns (for instance a value like "X') OR ('1'='1" bypasses the type filter and lists every table). passing each value through escape() keeps embedded quotes literal, in line with the recent getColumns change. i added a small regression test next to the existing metadata quote tests.