### PR TITLE
fix(jdbc): escape catalog and schema in foreign key metadata queries

### DIFF
--- a/src/main/java/org/sqlite/core/CoreDatabaseMetaData.java
+++ b/src/main/java/org/sqlite/core/CoreDatabaseMetaData.java
@@ -171,6 +171,9 @@ public abstract class CoreDatabaseMetaData implements DatabaseMetaData {
         // TODO: this function is ugly, pass this work off to SQLite, then we
         //       don't have to worry about Unicode 4, other characters needing
         //       escaping, etc.
+        if (val == null) {
+            return null;
+        }
         int len = val.length();
         StringBuilder buf = new StringBuilder(len);
         for (int i = 0; i < len; i++) {

--- a/src/main/java/org/sqlite/jdbc3/JDBC3DatabaseMetaData.java
+++ b/src/main/java/org/sqlite/jdbc3/JDBC3DatabaseMetaData.java
@@ -1157,18 +1157,18 @@ public abstract class JDBC3DatabaseMetaData extends CoreDatabaseMetaData {
 
         String query =
                 "select "
-                        + quote(pc)
+                        + quote(escape(pc))
                         + " as PKTABLE_CAT, "
-                        + quote(ps)
+                        + quote(escape(ps))
                         + " as PKTABLE_SCHEM, "
-                        + quote(pt)
+                        + quote(escape(pt))
                         + " as PKTABLE_NAME, "
                         + "'' as PKCOLUMN_NAME, "
-                        + quote(fc)
+                        + quote(escape(fc))
                         + " as FKTABLE_CAT, "
-                        + quote(fs)
+                        + quote(escape(fs))
                         + " as FKTABLE_SCHEM, "
-                        + quote(ft)
+                        + quote(escape(ft))
                         + " as FKTABLE_NAME, "
                         + "'' as FKCOLUMN_NAME, -1 as KEY_SEQ, 3 as UPDATE_RULE, 3 as DELETE_RULE, '' as FK_NAME, '' as PK_NAME, "
                         + DatabaseMetaData.importedKeyInitiallyDeferred
@@ -1256,8 +1256,8 @@ public abstract class JDBC3DatabaseMetaData extends CoreDatabaseMetaData {
         String[] pkColumns = pkFinder.getColumns();
         Statement stat = conn.createStatement();
 
-        catalog = (catalog != null) ? quote(catalog) : null;
-        schema = (schema != null) ? quote(schema) : null;
+        catalog = (catalog != null) ? quote(escape(catalog)) : null;
+        schema = (schema != null) ? quote(escape(schema)) : null;
 
         StringBuilder exportedKeysQuery = new StringBuilder(512);
 
@@ -1409,16 +1409,16 @@ public abstract class JDBC3DatabaseMetaData extends CoreDatabaseMetaData {
         StringBuilder sql = new StringBuilder(700);
 
         sql.append("select ")
-                .append(quote(catalog))
+                .append(quote(escape(catalog)))
                 .append(" as PKTABLE_CAT, ")
-                .append(quote(schema))
+                .append(quote(escape(schema)))
                 .append(" as PKTABLE_SCHEM, ")
                 .append("ptn as PKTABLE_NAME, pcn as PKCOLUMN_NAME, ")
-                .append(quote(catalog))
+                .append(quote(escape(catalog)))
                 .append(" as FKTABLE_CAT, ")
-                .append(quote(schema))
+                .append(quote(escape(schema)))
                 .append(" as FKTABLE_SCHEM, ")
-                .append(quote(table))
+                .append(quote(escape(table)))
                 .append(" as FKTABLE_NAME, ")
                 .append(
                         "fcn as FKCOLUMN_NAME, ks as KEY_SEQ, ur as UPDATE_RULE, dr as DELETE_RULE, fkn as FK_NAME, pkn as PK_NAME, ")

--- a/src/test/java/org/sqlite/DBMetaDataTest.java
+++ b/src/test/java/org/sqlite/DBMetaDataTest.java
@@ -487,6 +487,43 @@ public class DBMetaDataTest {
     }
 
     @Test
+    public void getImportedKeysCatalogSchemaWithQuote() throws SQLException {
+        stat.executeUpdate("create table parent (id integer primary key)");
+        stat.executeUpdate(
+                "create table child1 (id integer primary key, pid integer, foreign key(pid) references parent(id))");
+        // a catalog/schema containing a single quote must be carried through as a literal,
+        // not break out of the surrounding string in the generated metadata query
+        try (ResultSet rs = meta.getImportedKeys("ca'talog", "sch'ema", "child1")) {
+            assertThat(rs.next()).isTrue();
+            assertThat(rs.getString("PKTABLE_CAT")).isEqualTo("ca'talog");
+            assertThat(rs.getString("PKTABLE_SCHEM")).isEqualTo("sch'ema");
+        }
+    }
+
+    @Test
+    public void getExportedKeysCatalogSchemaWithQuote() throws SQLException {
+        stat.executeUpdate("create table parent (id integer primary key)");
+        stat.executeUpdate(
+                "create table child1 (id integer primary key, pid integer, foreign key(pid) references parent(id))");
+        try (ResultSet rs = meta.getExportedKeys("ca'talog", "sch'ema", "parent")) {
+            assertThat(rs.next()).isTrue();
+            assertThat(rs.getString("PKTABLE_CAT")).isEqualTo("ca'talog");
+            assertThat(rs.getString("PKTABLE_SCHEM")).isEqualTo("sch'ema");
+        }
+    }
+
+    @Test
+    public void getCrossReferenceCatalogSchemaWithQuote() throws SQLException {
+        stat.executeUpdate("create table parent (id integer primary key)");
+        stat.executeUpdate(
+                "create table child1 (id integer primary key, pid integer, foreign key(pid) references parent(id))");
+        try (ResultSet rs =
+                meta.getCrossReference("ca'talog", "sch'ema", "parent", null, null, "child1")) {
+            assertThat(rs.next()).isFalse();
+        }
+    }
+
+    @Test
     public void getColumnsTableNameWithQuote() throws SQLException {
         stat.executeUpdate("create table \"o'brien\" (id integer, name text)");
 


### PR DESCRIPTION
getCrossReference, getExportedKeys and getImportedKeys put the caller-supplied catalog, schema and table arguments straight into their metadata queries through quote(), which only wraps the value in single quotes and does no escaping, unlike the escape() helper used for the other identifiers nearby. So a catalog or schema containing a single quote (a perfectly legal argument to these DatabaseMetaData calls) breaks out of the string literal and the generated query fails or can be steered, which is a first-order SQL injection through the metadata layer. The fix routes each of these values through escape() before quote() and makes escape() null-safe so it slots in next to the existing null handling. I have added regression tests for the three methods using a single-quote in the catalog and schema.