### PR TITLE
fix(jdbc): escape resolved table name in getExportedKeys query

### DIFF
--- a/src/main/java/org/sqlite/jdbc3/JDBC3DatabaseMetaData.java
+++ b/src/main/java/org/sqlite/jdbc3/JDBC3DatabaseMetaData.java
@@ -1349,7 +1349,7 @@ public abstract class JDBC3DatabaseMetaData extends CoreDatabaseMetaData {
                 .append(" as PKTABLE_CAT, ")
                 .append(schema)
                 .append(" as PKTABLE_SCHEM, ")
-                .append(quote(target))
+                .append(quote(escape(target)))
                 .append(" as PKTABLE_NAME, ")
                 .append(hasImportedKey ? "pcn" : "''")
                 .append(" as PKCOLUMN_NAME, ")

--- a/src/test/java/org/sqlite/DBMetaDataTest.java
+++ b/src/test/java/org/sqlite/DBMetaDataTest.java
@@ -513,6 +513,21 @@ public class DBMetaDataTest {
     }
 
     @Test
+    public void getExportedKeysTableNameWithQuote() throws SQLException {
+        // the primary-key table name is read back from sqlite_schema and put into PKTABLE_NAME;
+        // a name containing a single quote must stay a literal, not break out of the generated
+        // query
+        stat.executeUpdate("create table \"o'parent\" (id integer primary key)");
+        stat.executeUpdate(
+                "create table child1 (id integer primary key, pid integer, foreign key(pid) references \"o'parent\"(id))");
+        try (ResultSet rs = meta.getExportedKeys(null, null, "o'parent")) {
+            assertThat(rs.next()).isTrue();
+            assertThat(rs.getString("PKTABLE_NAME")).isEqualTo("o'parent");
+            assertThat(rs.getString("FKTABLE_NAME")).isEqualTo("child1");
+        }
+    }
+
+    @Test
     public void getCrossReferenceCatalogSchemaWithQuote() throws SQLException {
         stat.executeUpdate("create table parent (id integer primary key)");
         stat.executeUpdate(


### PR DESCRIPTION
getExportedKeys builds its PKTABLE_NAME from the table name it reads back out of sqlite_schema, the case-correct form stored when the table was created, and that value goes into the query through quote() on its own without escape(). Every other identifier in these foreign-key queries already passes through escape(), and the recent catalog/schema change covered the caller-supplied arguments, but this resolved name was left raw. A table created with a single quote in its name (a legal quoted identifier) then breaks out of the literal when getExportedKeys is called for it, so the generated metadata query either errors or can be steered, the same second-order injection getColumns had. I noticed it while going back over the remaining quote() calls in the file after the earlier fixes landed. Routing target through escape() before quote() closes it and lines up with how the surrounding values are handled. I have added a regression test that creates a quoted-name parent table with a child foreign key pointing at it.