### PR TITLE
fix(pool): reset connection before notifying listeners on close

### DIFF
--- a/src/main/java/org/sqlite/javax/SQLitePooledConnection.java
+++ b/src/main/java/org/sqlite/javax/SQLitePooledConnection.java
@@ -91,13 +91,31 @@ public class SQLitePooledConnection extends JDBC4PooledConnection {
                                 getClass().getClassLoader(),
                                 new Class[] {Connection.class},
                                 new InvocationHandler() {
-                                    boolean isClosed;
+                                    volatile boolean isClosed;
 
                                     public Object invoke(Object proxy, Method method, Object[] args)
                                             throws Throwable {
                                         try {
                                             String name = method.getName();
                                             if ("close".equals(name)) {
+                                                // a handle may be closed twice: once by the
+                                                // client and again by getConnection() when the
+                                                // pooled connection is reused. only reset the
+                                                // physical connection once.
+                                                if (isClosed) {
+                                                    return null;
+                                                }
+
+                                                // reset the physical connection and mark this
+                                                // handle closed before notifying listeners, so the
+                                                // pool cannot hand the connection to another thread
+                                                // while the rollback/setAutoCommit is still running
+                                                if (!physicalConn.getAutoCommit()) {
+                                                    physicalConn.rollback();
+                                                }
+                                                physicalConn.setAutoCommit(true);
+                                                isClosed = true;
+
                                                 ConnectionEvent event =
                                                         new ConnectionEvent(
                                                                 SQLitePooledConnection.this);
@@ -105,12 +123,6 @@ public class SQLitePooledConnection extends JDBC4PooledConnection {
                                                 for (int i = listeners.size() - 1; i >= 0; i--) {
                                                     listeners.get(i).connectionClosed(event);
                                                 }
-
-                                                if (!physicalConn.getAutoCommit()) {
-                                                    physicalConn.rollback();
-                                                }
-                                                physicalConn.setAutoCommit(true);
-                                                isClosed = true;
 
                                                 return null; // don't close physical connection
                                             } else if ("isClosed".equals(name)) {

--- a/src/test/java/org/sqlite/SQLiteConnectionPoolDataSourceTest.java
+++ b/src/test/java/org/sqlite/SQLiteConnectionPoolDataSourceTest.java
@@ -19,6 +19,12 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.sql.ConnectionEvent;
+import javax.sql.ConnectionEventListener;
 import javax.sql.ConnectionPoolDataSource;
 import javax.sql.PooledConnection;
 import org.junit.jupiter.api.Disabled;
@@ -52,6 +58,74 @@ public class SQLiteConnectionPoolDataSourceTest {
 
         pooledConn.close();
         assertThat(handle.isClosed()).isTrue();
+    }
+
+    /**
+     * When a handle is closed the physical connection must be reset (rollback + auto-commit) before
+     * the pool is notified, otherwise a concurrent borrower can reuse the physical connection while
+     * the reset is still running. See issue #821.
+     */
+    @Test
+    public void concurrentReuseDoesNotRaceOnClose() throws Exception {
+        SQLiteConnectionPoolDataSource ds = new SQLiteConnectionPoolDataSource();
+        ds.setUrl("jdbc:sqlite::memory:");
+
+        DummyPool pool = new DummyPool(ds);
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+
+        List<Thread> threads = new ArrayList<>();
+        for (int i = 0; i < 8; i++) {
+            Thread t =
+                    new Thread(
+                            () -> {
+                                for (int j = 0; j < 2000 && failure.get() == null; j++) {
+                                    try (Connection c = pool.getConnection()) {
+                                        c.setAutoCommit(false);
+                                        c.createStatement().execute("select 1");
+                                    } catch (Throwable e) {
+                                        failure.compareAndSet(null, e);
+                                    }
+                                }
+                            });
+            threads.add(t);
+            t.start();
+        }
+        for (Thread t : threads) {
+            t.join();
+        }
+
+        assertThat(failure.get()).isNull();
+    }
+
+    /** Minimal pool that hands out and takes back pooled connections, like a real pool would. */
+    private static class DummyPool implements ConnectionEventListener {
+        private final List<PooledConnection> available = new ArrayList<>();
+        private final ConnectionPoolDataSource dataSource;
+
+        DummyPool(ConnectionPoolDataSource dataSource) {
+            this.dataSource = dataSource;
+        }
+
+        synchronized Connection getConnection() throws SQLException {
+            Iterator<PooledConnection> it = available.iterator();
+            PooledConnection pooled;
+            if (it.hasNext()) {
+                pooled = it.next();
+                it.remove();
+            } else {
+                pooled = dataSource.getPooledConnection();
+                pooled.addConnectionEventListener(this);
+            }
+            return pooled.getConnection();
+        }
+
+        @Override
+        public synchronized void connectionClosed(ConnectionEvent event) {
+            available.add((PooledConnection) event.getSource());
+        }
+
+        @Override
+        public void connectionErrorOccurred(ConnectionEvent event) {}
     }
 
     @Disabled


### PR DESCRIPTION
closing a pooled handle currently notifies the ConnectionEventListeners (which returns the connection to the pool) before it rolls back and resets the physical connection to auto-commit, so under concurrency another thread can borrow the pooled connection and start using the same physical connection while that reset is still in flight, which intermittently throws "cannot rollback - no transaction is active" as reported in #821. this reorders the close handler to reset the physical connection and mark the handle closed before notifying listeners, and makes close idempotent so the second close triggered when getConnection() reuses the handle does not reset again. added a small multi-threaded regression test that fails on master and passes with the change.
