### PR TITLE
fix(jdbc): map DATETIME column type to Types.TIMESTAMP

### DIFF
--- a/src/main/java/org/sqlite/jdbc3/JDBC3ResultSet.java
+++ b/src/main/java/org/sqlite/jdbc3/JDBC3ResultSet.java
@@ -642,11 +642,11 @@ public abstract class JDBC3ResultSet extends CoreResultSet {
                 return Types.BIGINT;
             }
 
-            if ("DATE".equals(typeName) || "DATETIME".equals(typeName)) {
+            if ("DATE".equals(typeName)) {
                 return Types.DATE;
             }
 
-            if ("TIMESTAMP".equals(typeName)) {
+            if ("DATETIME".equals(typeName) || "TIMESTAMP".equals(typeName)) {
                 return Types.TIMESTAMP;
             }
 
@@ -697,11 +697,11 @@ public abstract class JDBC3ResultSet extends CoreResultSet {
                 return Types.CLOB;
             }
 
-            if ("DATE".equals(typeName) || "DATETIME".equals(typeName)) {
+            if ("DATE".equals(typeName)) {
                 return Types.DATE;
             }
 
-            if ("TIMESTAMP".equals(typeName)) {
+            if ("DATETIME".equals(typeName) || "TIMESTAMP".equals(typeName)) {
                 return Types.TIMESTAMP;
             }
 

--- a/src/test/java/org/sqlite/RSMetaDataTest.java
+++ b/src/test/java/org/sqlite/RSMetaDataTest.java
@@ -125,7 +125,7 @@ public class RSMetaDataTest {
         assertThat(meta.getColumnType(25)).isEqualTo(Types.BOOLEAN);
 
         assertThat(meta.getColumnType(26)).isEqualTo(Types.DATE);
-        assertThat(meta.getColumnType(27)).isEqualTo(Types.DATE);
+        assertThat(meta.getColumnType(27)).isEqualTo(Types.TIMESTAMP);
 
         assertThat(meta.getColumnType(28)).isEqualTo(Types.TIMESTAMP);
         assertThat(meta.getColumnType(29)).isEqualTo(Types.CHAR);
@@ -165,6 +165,46 @@ public class RSMetaDataTest {
         assertThat(meta.isSigned(5)).isFalse();
 
         assertThat(rs.next()).isFalse();
+    }
+
+    @Test
+    public void datetimeColumnTypeIsTimestamp() throws SQLException {
+        stat.executeUpdate(
+                "CREATE TABLE mytable ("
+                        + "\"fid\" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, "
+                        + "\"date_creation\" DATETIME)");
+
+        try (ResultSet rs = stat.executeQuery("SELECT * FROM mytable")) {
+            ResultSetMetaData rsmd = rs.getMetaData();
+            assertThat(rsmd.getColumnTypeName(2)).isEqualTo("DATETIME");
+            assertThat(rsmd.getColumnType(2)).isEqualTo(Types.TIMESTAMP);
+        }
+
+        stat.executeUpdate("INSERT INTO mytable(date_creation) VALUES ('2024-01-15 13:45:30.123')");
+        try (ResultSet rs = stat.executeQuery("SELECT * FROM mytable")) {
+            assertThat(rs.next()).isTrue();
+            ResultSetMetaData rsmd = rs.getMetaData();
+            assertThat(rsmd.getColumnType(2)).isEqualTo(Types.TIMESTAMP);
+            assertThat(rs.getTimestamp(2))
+                    .isEqualTo(java.sql.Timestamp.valueOf("2024-01-15 13:45:30.123"));
+        }
+
+        stat.executeUpdate("DELETE FROM mytable");
+        stat.executeUpdate("INSERT INTO mytable(date_creation) VALUES (1705326330)");
+        try (ResultSet rs = stat.executeQuery("SELECT * FROM mytable")) {
+            assertThat(rs.next()).isTrue();
+            ResultSetMetaData rsmd = rs.getMetaData();
+            assertThat(rsmd.getColumnTypeName(2)).isEqualTo("DATETIME");
+            assertThat(rsmd.getColumnType(2)).isEqualTo(Types.TIMESTAMP);
+        }
+
+        stat.executeUpdate("CREATE TABLE temporal (d DATE, dt DATETIME, ts TIMESTAMP)");
+        try (ResultSet rs = stat.executeQuery("SELECT * FROM temporal")) {
+            ResultSetMetaData rsmd = rs.getMetaData();
+            assertThat(rsmd.getColumnType(1)).isEqualTo(Types.DATE);
+            assertThat(rsmd.getColumnType(2)).isEqualTo(Types.TIMESTAMP);
+            assertThat(rsmd.getColumnType(3)).isEqualTo(Types.TIMESTAMP);
+        }
     }
 
     @Test


### PR DESCRIPTION
`ResultSetMetaData.getColumnType()` was mapping declared `DATETIME` columns to `Types.DATE`, same as plain `DATE`. That looks wrong: a `DATETIME` value can include a time component (`2024-01-15 13:45:30.123`), and `TIMESTAMP` already returned `Types.TIMESTAMP`. Clients that pick `getDate()` vs `getTimestamp()` from the reported JDBC type end up dropping the time.

I changed both the integer and text branches in `JDBC3ResultSet#getColumnType` so `DATETIME` is reported as `Types.TIMESTAMP`, and left `DATE` alone. Updated the existing type matrix assertion and added a regression test covering the empty-result case from #1436, text and integer storage, and DATE/DATETIME/TIMESTAMP side by side.

Fixes #1436