### PR TITLE
fix(jdbc): throw SQLException from createConnection on invalid URL

### DIFF
--- a/src/main/java/org/sqlite/JDBC.java
+++ b/src/main/java/org/sqlite/JDBC.java
@@ -76,6 +76,9 @@ public class JDBC implements Driver {
 
     /** @see java.sql.Driver#connect(java.lang.String, java.util.Properties) */
     public Connection connect(String url, Properties info) throws SQLException {
+        if (!isValidURL(url)) {
+            return null;
+        }
         return createConnection(url, info);
     }
 
@@ -92,15 +95,20 @@ public class JDBC implements Driver {
     /**
      * Creates a new database connection to a given URL.
      *
+     * <p>Unlike {@link #connect(String, Properties)}, this method throws {@link SQLException} when
+     * the URL is not a {@code jdbc:sqlite:} address, rather than returning {@code null}.
+     *
      * @param url the URL
      * @param prop the properties
      * @return a Connection object that represents a connection to the URL
-     * @throws SQLException
-     * @see java.sql.Driver#connect(java.lang.String, java.util.Properties)
+     * @throws SQLException if the URL is not a valid SQLite JDBC URL, or if a database access error
+     *     occurs
      */
     public static SQLiteConnection createConnection(String url, Properties prop)
             throws SQLException {
-        if (!isValidURL(url)) return null;
+        if (!isValidURL(url)) {
+            throw new SQLException("invalid database address: " + url);
+        }
 
         url = url.trim();
         return new JDBC4Connection(url, extractAddress(url), prop);

--- a/src/test/java/org/sqlite/JDBCTest.java
+++ b/src/test/java/org/sqlite/JDBCTest.java
@@ -48,8 +48,32 @@ public class JDBCTest {
     }
 
     @Test
-    public void shouldReturnNullIfProtocolUnhandled() throws Exception {
-        assertThat(JDBC.createConnection("jdbc:anotherpopulardatabaseprotocol:", null)).isNull();
+    public void createConnectionThrowsIfProtocolUnhandled() {
+        assertThatExceptionOfType(SQLException.class)
+                .isThrownBy(
+                        () -> JDBC.createConnection("jdbc:anotherpopulardatabaseprotocol:", null))
+                .withMessageContaining("invalid database address");
+    }
+
+    @Test
+    public void driverConnectReturnsNullIfProtocolUnhandled() throws Exception {
+        assertThat(new JDBC().connect("jdbc:anotherpopulardatabaseprotocol:", null)).isNull();
+        assertThat(new JDBC().connect("jdbc:wrongprotocol:test.db", new Properties())).isNull();
+    }
+
+    @Test
+    public void createConnectionThrowsOnNullUrl() {
+        assertThatExceptionOfType(SQLException.class)
+                .isThrownBy(() -> JDBC.createConnection(null, null))
+                .withMessageContaining("invalid database address");
+    }
+
+    @Test
+    public void createConnectionAcceptsValidSqliteUrl() throws Exception {
+        try (Connection conn = JDBC.createConnection("jdbc:sqlite:", new Properties())) {
+            assertThat(conn).isNotNull();
+            assertThat(conn.isClosed()).isFalse();
+        }
     }
 
     @Test


### PR DESCRIPTION
`JDBC.createConnection()` has been returning `null` for URLs that are not `jdbc:sqlite:` ever since 392b7e7. That is the right behaviour for `Driver.connect()` so `DriverManager` can walk the registered drivers, but the static helper is used directly by callers (and by things like `SQLiteDataSource` / ScalaSql) that expect either a real connection or an exception. They currently fall over later with an NPE instead.

I split the two paths: `connect()` still returns `null` when the protocol is not ours, and `createConnection()` throws `SQLException("invalid database address: …")` again like it did before that change. Javadoc on the static method notes the difference so we do not glue them back together by accident.

Updated the old test that asserted `null` from `createConnection`, and added coverage for `Driver.connect` returning `null`, null URL, and a valid `jdbc:sqlite:` URL.

Fixes #1374