### PR TITLE
fix: bound utf-8 reader to the terminating nul in extension-functions

### DIFF
--- a/src/main/ext/extension-functions.c
+++ b/src/main/ext/extension-functions.c
@@ -286,9 +286,12 @@ static const int utf_mask[] = {
   xtra = xtra_utf8_bytes[c];                           \
   switch( xtra ){                                      \
     case 4: c = (int)0xFFFD; break;                    \
-    case 3: c = (c<<6) + *(zIn)++;                     \
-    case 2: c = (c<<6) + *(zIn)++;                     \
-    case 1: c = (c<<6) + *(zIn)++;                     \
+    case 3: if((*(zIn)&0xc0)!=0x80){c=0xFFFD;break;}   \
+            c = (c<<6) + *(zIn)++;                     \
+    case 2: if((*(zIn)&0xc0)!=0x80){c=0xFFFD;break;}   \
+            c = (c<<6) + *(zIn)++;                     \
+    case 1: if((*(zIn)&0xc0)!=0x80){c=0xFFFD;break;}   \
+            c = (c<<6) + *(zIn)++;                     \
     c -= xtra_utf8_bits[xtra];                         \
     if( (utf_mask[xtra]&c)==0                          \
         || (c&0xFFFFF800)==0xD800                      \


### PR DESCRIPTION
**out-of-bounds read on a truncated utf-8 sequence in extension-functions**

the multibyte reader behind reverse/proper/charindex/leftstr/rightstr/strfilter/difference reads the trailing bytes a lead byte announces without checking for the string's terminating nul, so a value ending in a truncated sequence such as `reverse(cast(x'f0' as text))` makes it walk a few bytes past the allocation, a heap over-read reachable from ordinary sql. this stops the read as soon as the next byte is not a continuation byte, so a truncated character resolves to U+FFFD and well-formed utf-8 decodes exactly as before.